### PR TITLE
fix: ensure fetch includes cookies for cross-origin requests

### DIFF
--- a/frontend/src/utils/fetchInterceptor.js
+++ b/frontend/src/utils/fetchInterceptor.js
@@ -8,8 +8,10 @@ window.fetch = async function(input, init = {}) {
   const headers = new Headers(options.headers || {});
   const isAuth = /\/api\/v1\/auth\//.test(url);
 
-  // Ensure cookies are sent for API calls
-  const credentials = options.credentials || 'same-origin';
+  // Ensure cookies are sent for API calls. We default to 'include' so that
+  // cross-origin requests (e.g. different ports during local development)
+  // still include authentication cookies.
+  const credentials = options.credentials || 'include';
 
   try {
     const response = await nativeFetch(input, { ...options, headers, credentials });


### PR DESCRIPTION
## Summary
- include credentials by default in global fetch interceptor so auth cookies are sent

## Testing
- `npm test -- --watchAll=false` *(failed: Registration error and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c6814be6e8832a8d51b50e5fa097d0