### PR TITLE
Add superadmin, icons, and admin redirect

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -24,7 +24,7 @@ import {
   Logout as LogoutIcon,
   Dashboard as DashboardIcon,
   SportsEsports as GamesIcon,
-  People as PeopleIcon,
+  PersonOutline as PlayersIcon,
   HelpOutline as HelpIcon,
   NotificationsNone as NotificationsIcon
 } from '@mui/icons-material';
@@ -46,7 +46,7 @@ const Navbar = () => {
   const navigation = [
     { name: 'Dashboard', path: '/dashboard', icon: <DashboardIcon />, auth: true },
     { name: 'Games', path: '/games', icon: <GamesIcon />, auth: true },
-    { name: 'Players', path: '/players', icon: <PeopleIcon />, auth: true },
+    { name: 'Players', path: '/players', icon: <PlayersIcon />, auth: true },
   ];
 
   const handleMenuOpen = (event) => {

--- a/frontend/src/pages/GamesList.js
+++ b/frontend/src/pages/GamesList.js
@@ -29,7 +29,7 @@ import {
   Divider,
   Stack,
 } from '@mui/material';
-import { PlayArrow, Edit, Delete, Add, Settings, FileDownloadOutlined } from '@mui/icons-material';
+import { PlayArrow, Edit, Delete, Add, Settings, FileDownloadOutlined, SportsEsports, PersonOutline } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import gameApi from '../services/gameApi';
 // Removed Chakra UI components to avoid runtime errors when the Chakra provider
@@ -327,12 +327,14 @@ const GamesList = () => {
           </Button>
           <Button
             variant="outlined"
+            startIcon={<SportsEsports />}
             onClick={() => navigate('/supply-chain-config')}
           >
             Game Configuration
           </Button>
           <Button
             variant="outlined"
+            startIcon={<PersonOutline />}
             onClick={() => navigate('/players')}
           >
             Players
@@ -366,10 +368,10 @@ const GamesList = () => {
           <Button variant="outlined" startIcon={<Settings />} onClick={() => navigate('/system-config')}>
             SC Configuration
           </Button>
-          <Button variant="outlined" onClick={() => navigate('/supply-chain-config')}>
+          <Button variant="outlined" startIcon={<SportsEsports />} onClick={() => navigate('/supply-chain-config')}>
             Game Configuration
           </Button>
-          <Button variant="outlined" onClick={() => navigate('/players')}>
+          <Button variant="outlined" startIcon={<PersonOutline />} onClick={() => navigate('/players')}>
             Players
           </Button>
           <Button variant="outlined" onClick={() => navigate('/admin/training')}>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -23,10 +23,10 @@ const Login = () => {
       if (!isAuthenticated) return;
       const redirectTo = searchParams.get('redirect');
 
-      // If admin, honor redirect or go to games
+      // If admin/superadmin, honor redirect or go to players page
       const isAdmin = user?.is_superuser || (Array.isArray(user?.roles) && user.roles.includes('admin'));
       if (isAdmin) {
-        navigate(redirectTo || '/', { replace: true });
+        navigate(redirectTo || '/players', { replace: true });
         return;
       }
 
@@ -111,9 +111,12 @@ const Login = () => {
           } catch (e) {
             // ignore and fall back
           }
+          const redirectTo = searchParams.get('redirect') || '/games';
+          navigate(redirectTo, { replace: true });
+        } else {
+          const redirectTo = searchParams.get('redirect') || '/players';
+          navigate(redirectTo, { replace: true });
         }
-        const redirectTo = searchParams.get('redirect') || '/games';
-        navigate(redirectTo, { replace: true });
       } else if (error) {
         toast.error(error);
       }

--- a/init_db.sql
+++ b/init_db.sql
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS users (
 -- Password for all users is 'Daybreak@2025' (hashed with bcrypt)
 INSERT IGNORE INTO users (username, email, hashed_password, full_name, is_superuser, is_active) VALUES
 ('admin', 'admin@daybreak.ai', '$2b$12$EixZaYVK1fsbw1ZfbX3OXePaWxn96p36WQoeG6Lruj3vjPGga31lW', 'System Administrator', TRUE, TRUE),
+('superadmin', 'superadmin@daybreak.ai', '$2b$12$/FAxQ94QmW1WFdMZd5nKzegYJZkZSi.JUSX/4IvImY3cE2vtleAu6', 'Super Admin', TRUE, TRUE),
 ('Retailer', 'retailer@daybreak.ai', '$2b$12$EixZaYVK1fsbw1ZfbX3OXePaWxn96p36WQoeG6Lruj3vjPGga31lW', 'Retailer User', FALSE, TRUE),
 ('Distributor', 'distributor@daybreak.ai', '$2b$12$EixZaYVK1fsbw1ZfbX3OXePaWxn96p36WQoeG6Lruj3vjPGga31lW', 'Distributor User', FALSE, TRUE),
 ('Manufacturer', 'manufacturer@daybreak.ai', '$2b$12$EixZaYVK1fsbw1ZfbX3OXePaWxn96p36WQoeG6Lruj3vjPGga31lW', 'Manufacturer User', FALSE, TRUE),


### PR DESCRIPTION
## Summary
- seed superadmin account with default credentials
- add icons for Game Configuration and Players buttons
- redirect admins to Players page after login and update navbar icon

## Testing
- `npm test -- --watchAll=false` *(fails: React testing warnings and failing suites)*
- `pytest` *(fails: missing import and module mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68c699616040832a8ca0a24391c4b307