### PR TITLE
Add default LLM players and show game context in navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A comprehensive simulation of the Beer Distribution Game featuring AI-powered su
 - **Advanced Analytics**: Real-time supply chain metrics and visualization
 - **AI-Powered Insights**: Machine learning models for demand forecasting and optimization
 - **Multiplayer Support**: Play with both human and AI players
+- **Automatic LLM Players**: Default retailer, wholesaler, distributor, and manufacturer players are created as LLM agents when a group is created
 - **Containerized Deployment**: Easy setup with Docker and Docker Compose
 
 ## 🚀 Features


### PR DESCRIPTION
## Summary
- Automatically create retailer, wholesaler, distributor, and manufacturer players with LLM agent strategy when a superadmin creates a group
- Display active Group | SC | Game in the navbar for logged-in players
- Document automatic creation of LLM players for new groups

## Testing
- `pytest -k "not test_db_connection"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c70b452ab4832aa74112d577fec304