### PR TITLE
Fix create-users DB password mismatch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
       - MYSQL_SERVER=db
       - MYSQL_PORT=3306
       - MYSQL_USER=beer_user
-      - MYSQL_PASSWORD=Daybreak@2025
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-beer_password}
       - MYSQL_DB=beer_game
     depends_on:
       db:


### PR DESCRIPTION
## Summary
- Align create-users service's MySQL password with database configuration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c7c9d2e1c0832aaa1f4222248af419