### PR TITLE
Use Daybreak Beer Game Strategist instructions

### DIFF
--- a/llm_agent/daybreak_tbg_agent.py
+++ b/llm_agent/daybreak_tbg_agent.py
@@ -23,17 +23,15 @@ def call_beer_game_gpt(user_message: str):
     gpt_id = os.getenv("GPT_ID", "gpt-50")
 
     request_args = {
-        "model": "gpt-4o",
+        "model": "gpt-4.1-mini",
         "gpt": gpt_id,
-        "messages": [
-            {"role": "system", "content": "You are Daybreak Beer Game Strategist."},
-            {"role": "user", "content": user_message},
-        ],
-        "tool_choice": "auto",
+        "instructions": "You are Daybreak Beer Game Strategist.",
+        "input": user_message,
+        "tools": [{"type": "code_interpreter"}],
     }
 
-    response = client.chat.completions.create(**request_args)
-    reply = response.choices[0].message.content
+    response = client.responses.create(**request_args)
+    reply = response.output_text
     print("FULL RESPONSE:\n", reply)
 
     order_match = re.search(r"ORDER:\s*(\d+)", reply)


### PR DESCRIPTION
## Summary
- Update `call_beer_game_gpt` to use `client.responses.create`
- Send Daybreak Beer Game Strategist instructions via `instructions`
- Enable code interpreter tool when querying custom GPT

## Testing
- `python -m py_compile llm_agent/daybreak_tbg_agent.py`
- `pytest llm_agent -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e6dc17a0832aa13ee80ee72a0528