### PR TITLE
Fix database initialization and user creation

### DIFF
--- a/backend/app/models/supply_chain_config.py
+++ b/backend/app/models/supply_chain_config.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from enum import Enum as PyEnum
 from typing import List, Optional, TYPE_CHECKING
 import datetime
-from app.db.base import Base
+from .base import Base
 
 if TYPE_CHECKING:
     from .group import Group

--- a/backend/scripts/create_users.py
+++ b/backend/scripts/create_users.py
@@ -12,6 +12,7 @@ from app.models.base import Base
 from app.models.user import User
 from app.models.player import Player, PlayerRole, PlayerType, PlayerStrategy
 from app.models.group import Group
+from app.models.supply_chain_config import SupplyChainConfig  # noqa: F401
 from app.core.config import settings
 
 # Password hashing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,7 +149,7 @@ services:
       - MYSQL_SERVER=db
       - MYSQL_PORT=3306
       - MYSQL_USER=beer_user
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-change-me-user}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-beer_password}
       - MYSQL_DB=beer_game
     depends_on:
       db:

--- a/scripts/init_database.sh
+++ b/scripts/init_database.sh
@@ -40,12 +40,9 @@ mysql -h localhost -u root -p"$MARIADB_ROOT_PASSWORD" -e "
 
 log "✅ Database and user created successfully"
 
-# Import schema if it exists
-if [ -f "/docker-entrypoint-initdb.d/init_db.sql" ]; then
-    log "Importing database schema..."
-    mysql -h localhost -u root -p"$MARIADB_ROOT_PASSWORD" "$MARIADB_DATABASE" < /docker-entrypoint-initdb.d/init_db.sql
-    log "✅ Database schema imported successfully"
-fi
+# The init_db.sql file will be executed automatically by the MariaDB
+# entrypoint after this script completes, so we no longer import it here
+# to avoid running the schema twice and causing duplicate key errors.
 
 # Run migrations if alembic is available
 if command -v alembic &> /dev/null; then


### PR DESCRIPTION
## Summary
- prevent duplicate schema imports in MariaDB init script
- align SupplyChainConfig model with core Base and register in user creation script
- standardize DB password for create-users service

## Testing
- `python -m py_compile backend/scripts/create_users.py backend/app/models/supply_chain_config.py`
- `bash -n scripts/init_database.sh`
- ❌ `docker-compose config -q` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e7a6edb0832ab283041795541f82