### PR TITLE
Add LLM model selection and strategist adapter

### DIFF
--- a/backend/alembic/versions/202409300001_add_llm_model_to_players.py
+++ b/backend/alembic/versions/202409300001_add_llm_model_to_players.py
@@ -1,0 +1,20 @@
+"""add llm_model column to players"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '202409300001'
+down_revision = '1234abcd5678'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column(
+        'players',
+        sa.Column('llm_model', sa.String(length=100), server_default='gpt-4o-mini', nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column('players', 'llm_model')

--- a/backend/app/models/player.py
+++ b/backend/app/models/player.py
@@ -46,6 +46,10 @@ class Player(Base):
     role: Mapped[PlayerRole] = mapped_column(SQLEnum(PlayerRole), nullable=False)
     type: Mapped[PlayerType] = mapped_column(SQLEnum(PlayerType), default=PlayerType.HUMAN)
     strategy: Mapped[PlayerStrategy] = mapped_column(SQLEnum(PlayerStrategy), default=PlayerStrategy.MANUAL)
+    is_ai: Mapped[bool] = mapped_column(Boolean, default=False)
+    ai_strategy: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    can_see_demand: Mapped[bool] = mapped_column(Boolean, default=False)
+    llm_model: Mapped[Optional[str]] = mapped_column(String(100), nullable=True, default="gpt-4o-mini")
     
     # Inventory and order tracking
     inventory: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/app/schemas/player.py
+++ b/backend/app/schemas/player.py
@@ -34,7 +34,9 @@ class PlayerAssignment(BaseModel):
     user_id: Optional[int] = None  # Required for human players
     strategy: Optional[PlayerStrategy] = PlayerStrategy.NAIVE  # For AI players
     can_see_demand: bool = False  # Whether this player can see customer demand
-    llm_model: Optional[str] = None  # Optional: selected LLM when using LLM strategies
+    llm_model: Optional[str] = Field(
+        default="gpt-4o-mini", description="Selected LLM when using LLM strategies"
+    )
     llm_config: Optional[dict] = None  # temperature, max_tokens, prompt
     basic_config: Optional[dict] = None  # heuristic params, e.g., base_stock_target, smoothing
 
@@ -60,6 +62,7 @@ class PlayerResponse(BaseModel):
     name: str
     strategy: Optional[PlayerStrategy]
     can_see_demand: bool
+    llm_model: Optional[str] = None
     is_ready: bool = False
 
     class Config:
@@ -69,4 +72,5 @@ class PlayerUpdate(BaseModel):
     """Schema for updating player information."""
     strategy: Optional[PlayerStrategy] = None
     can_see_demand: Optional[bool] = None
+    llm_model: Optional[str] = None
     is_ready: Optional[bool] = None

--- a/backend/app/services/mixed_game_service.py
+++ b/backend/app/services/mixed_game_service.py
@@ -94,6 +94,7 @@ class MixedGameService:
                 is_ai=is_ai,
                 ai_strategy=(assignment.strategy.value if hasattr(assignment.strategy, 'value') else str(assignment.strategy)) if is_ai else None,
                 can_see_demand=assignment.can_see_demand,
+                llm_model=assignment.llm_model if is_ai else None,
                 user_id=assignment.user_id if not is_ai else None
             )
             self.db.add(player)

--- a/llm_agent/strategist_adapter.py
+++ b/llm_agent/strategist_adapter.py
@@ -1,0 +1,169 @@
+"""OpenAI Strategist adapter for the Beer Game simulator."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+from openai import OpenAI
+from pydantic import BaseModel, Field
+
+DEFAULT_BASE_URL = os.getenv("BEERGAME_API_BASE_URL", "http://localhost:8000")
+LOG = logging.getLogger(__name__)
+
+
+class BeerGameClient:
+    """Simple REST client for the Beer Game backend."""
+
+    def __init__(self, base_url: str = DEFAULT_BASE_URL):
+        self.base_url = base_url.rstrip("/")
+        self.openapi: Optional[Dict[str, Any]] = self._load_openapi()
+
+    def _load_openapi(self) -> Optional[Dict[str, Any]]:
+        try:
+            resp = requests.get(f"{self.base_url}/openapi.json", timeout=5)
+            if resp.status_code == 200:
+                return resp.json()
+        except Exception:
+            pass
+        return None
+
+    def _post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        resp = requests.post(url, json=payload, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _get(self, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        resp = requests.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+
+    def run_simulation(self, **kwargs) -> Dict[str, Any]:
+        path = "/api/sim/run"
+        return self._post(path, kwargs)
+
+    def get_kpis(self, **kwargs) -> Dict[str, Any]:
+        path = "/api/kpis"
+        return self._get(path, kwargs)
+
+
+class RunBeerGameSimRequest(BaseModel):
+    demand: List[int] = Field(..., description="Demand series")
+    lead_time: int = Field(..., description="Lead time in weeks")
+    initial_inventory: int = Field(..., description="Starting inventory")
+
+
+class GetKpisRequest(BaseModel):
+    window: int = Field(4, description="Rolling window in weeks")
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "run_beer_game_sim",
+            "description": "Run a Beer Game simulation and return the state history.",
+            "parameters": RunBeerGameSimRequest.schema(),
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_kpis",
+            "description": "Compute KPIs over the last N rounds.",
+            "parameters": GetKpisRequest.schema(),
+        },
+    },
+]
+
+INSTRUCTIONS = (
+    "You are the Beer Game Strategist. Use the provided tools to simulate supply chain "
+    "scenarios and report key metrics."
+)
+
+
+def make_openai_client() -> OpenAI:
+    return OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+def _handle_tool_calls(
+    client: OpenAI,
+    response_id: str,
+    tool_calls: List[Dict[str, Any]],
+    sim_api: BeerGameClient,
+) -> str:
+    outputs = []
+    for call in tool_calls:
+        name = call.get("name")
+        args = json.loads(call.get("arguments", "{}"))
+        if name == "run_beer_game_sim":
+            result = sim_api.run_simulation(**args)
+        elif name == "get_kpis":
+            result = sim_api.get_kpis(**args)
+        else:
+            result = {"error": f"unknown tool {name}"}
+        outputs.append({"tool_call_id": call.get("id"), "output": json.dumps(result)})
+
+    followup = client.responses.submit_tool_outputs(
+        response_id=response_id, tool_outputs=outputs
+    )
+    return getattr(followup, "output_text", str(followup))
+
+
+def strategist_query(
+    user_input: str,
+    *,
+    model: str = "gpt-4o-mini",
+    base_url: str = DEFAULT_BASE_URL,
+) -> str:
+    sim_api = BeerGameClient(base_url=base_url)
+    ai = make_openai_client()
+
+    resp = ai.responses.create(
+        model=model,
+        instructions=INSTRUCTIONS,
+        input=user_input,
+        tools=TOOLS,
+    )
+
+    tool_calls: List[Dict[str, Any]] = []
+    for block in getattr(resp, "output", []) or []:
+        if getattr(block, "type", None) == "tool_call":
+            tool_calls.append(
+                {
+                    "id": getattr(block, "id", None),
+                    "name": getattr(block, "name", None),
+                    "arguments": getattr(block, "arguments", None),
+                }
+            )
+
+    if tool_calls:
+        return _handle_tool_calls(ai, resp.id, tool_calls, sim_api)
+
+    return getattr(resp, "output_text", str(resp))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    base = os.getenv("BEERGAME_API_BASE_URL", DEFAULT_BASE_URL)
+    LOG.info("Using backend: %s", base)
+    client = BeerGameClient(base_url=base)
+    if client.openapi:
+        LOG.info("OpenAPI titles: %s", client.openapi.get("info", {}).get("title"))
+    else:
+        LOG.warning("OpenAPI missing; using default paths")
+
+    try:
+        answer = strategist_query(
+            "Demand ~40±15 weekly, lead 2w, initial inv 100. Propose low‑WIP policy and A/B sim plan.",
+            model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            base_url=base,
+        )
+        print("\n=== Strategist Answer ===\n", answer)
+    except Exception as exc:
+        LOG.error("Strategist run failed: %s", exc)


### PR DESCRIPTION
## Summary
- store chosen LLM model for each player and expose default `gpt-4o-mini`
- allow LLM model selection on the mixed game creation page
- add adapter wiring OpenAI strategist agent to the Beer Game simulator

## Testing
- `pytest` *(fails: No module named 'torch')*
- `CI=true npm test` *(fails: 5 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f8454ee4832aad2fdc03dcbc0531