### PR TITLE
Add OS-aware environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,10 @@ logs/
 # Env files
 .env
 .env.local
-.env.development.local
-.env.production.local
-.env.test.local
+.env.*
+!.env.example
+!.env.dev
+!.env.prod
 
 # Bundles/archives
 *.zip

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 SHELL := /bin/bash
 
+ifeq ($(OS),Windows_NT)
+    SETUP_ENV := powershell -ExecutionPolicy Bypass -File scripts/setup_env.ps1
+else
+    SETUP_ENV := bash scripts/setup_env.sh
+endif
+
 # Default to localhost for local development
 HOST = localhost
 REMOTE_HOST = 172.29.20.187
@@ -16,7 +22,7 @@ DOCKER_BUILD_ARGS_GPU = --build-arg FORCE_GPU=1
 # Docker runtime arguments
 DOCKER_RUN_ARGS = -e FORCE_GPU=$(FORCE_GPU)
 
-.PHONY: up gpu-up up-dev down ps logs seed reset-admin help
+.PHONY: up gpu-up up-dev down ps logs seed reset-admin help init-env
 
 # Default CPU target
 up:
@@ -148,16 +154,20 @@ help:
 	echo "  make rebuild-backend  - rebuild and restart only backend"; \
         echo "  make seed          - run user seeder (superadmin user)"; \
         echo "  make reset-admin   - reset superadmin password to Daybreak@2025"; \
-	echo "  make proxy-url     - print URLs and login info"; \
-	echo ""; \
-	echo "Advanced Training:"; \
+        echo "  make proxy-url     - print URLs and login info"; \
+        echo "  make init-env      - set up .env from template or host-specific file"; \
+        echo ""; \
+        echo "Advanced Training:"; \
 	echo "  make train-setup   - create Python venv and install training deps"; \
 	echo "  make train-cpu     - run local CPU training"; \
 	echo "  make train-gpu     - run local GPU training"; \
 	echo "  make remote-train  - train on remote server"; \
 	echo ""; \
 	echo "Environment Variables:"; \
-	echo "  FORCE_GPU=1        - Enable GPU support (e.g., make up FORCE_GPU=1)";
+        echo "  FORCE_GPU=1        - Enable GPU support (e.g., make up FORCE_GPU=1)";
+
+init-env:
+	@$(SETUP_ENV)
 
 # Remote training wrappers (see scripts/remote_train.sh for full help)
 REMOTE        ?=

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A comprehensive simulation of the Beer Distribution Game featuring AI-powered su
 
 2. Copy the example environment files:
    ```bash
-   cp .env.example .env
+   make init-env
    cp frontend/.env.example frontend/.env
    ```
 
@@ -118,7 +118,7 @@ beer-game/
 ### Installation
 
 1. Clone the repository
-2. Set up environment variables (copy `.env.example` to `.env` and configure)
+2. Set up environment variables (`make init-env` copies `.env.example` to `.env` or, if present, copies `.env.<hostname>` for machine-specific settings)
 3. Run `docker-compose up --build`
 
 ### Development

--- a/scripts/setup_env.ps1
+++ b/scripts/setup_env.ps1
@@ -1,0 +1,15 @@
+$hostname = $env:COMPUTERNAME
+$hostEnv = ".env.$hostname"
+
+if (Test-Path $hostEnv) {
+    Copy-Item $hostEnv ".env" -Force
+    Write-Host "Loaded environment from $hostEnv"
+}
+elseif (Test-Path ".env.local") {
+    Copy-Item ".env.local" ".env" -Force
+    Write-Host "Loaded environment from .env.local"
+}
+else {
+    Copy-Item ".env.example" ".env" -Force
+    Write-Host "Created .env from .env.example"
+}

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Sets up a local .env based on hostname or example template
+set -e
+
+HOSTNAME=$(hostname)
+HOST_ENV=".env.$HOSTNAME"
+
+if [ -f "$HOST_ENV" ]; then
+  cp "$HOST_ENV" .env
+  echo "Loaded environment from $HOST_ENV"
+elif [ -f ".env.local" ]; then
+  cp .env.local .env
+  echo "Loaded environment from .env.local"
+else
+  cp .env.example .env
+  echo "Created .env from .env.example"
+fi


### PR DESCRIPTION
## Summary
- add `init-env` Makefile target that runs the correct env-setup script depending on OS
- provide bash and PowerShell scripts that copy `.env.<hostname>` or `.env.example` to `.env`
- ignore machine-specific `.env.*` files and document the new workflow in README

## Testing
- `make init-env`


------
https://chatgpt.com/codex/tasks/task_e_68c81a3f3948832a8050033ccfb562ea