### PR TITLE
Improve login feedback for missing or incorrect credentials

### DIFF
--- a/frontend/src/components/ContactSuperadminForm.jsx
+++ b/frontend/src/components/ContactSuperadminForm.jsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+
+const DEFAULT_SUPERADMIN_EMAIL = 'superadmin@daybreak.ai';
+
+const ContactSuperadminForm = ({ email, superadminEmail = DEFAULT_SUPERADMIN_EMAIL, onClose }) => {
+  const [name, setName] = useState('');
+  const [notes, setNotes] = useState('');
+  const contactEmail = superadminEmail || DEFAULT_SUPERADMIN_EMAIL;
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    const lines = [];
+    lines.push('Hello Superadmin,');
+
+    if (name.trim()) {
+      lines.push(`My name is ${name.trim()}.`);
+    }
+
+    lines.push('I tried to sign in to The Beer Game platform but do not have login credentials yet.');
+
+    if (email) {
+      lines.push(`Attempted login email: ${email}`);
+    }
+
+    if (notes.trim()) {
+      lines.push('', notes.trim());
+    }
+
+    lines.push('', 'Could you please help me get set up with the correct access credentials?', '', 'Thank you!');
+
+    const subject = 'Access request for The Beer Game';
+    const body = encodeURIComponent(lines.join('\n'));
+
+    if (typeof window !== 'undefined') {
+      window.location.href = `mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&body=${body}`;
+    }
+
+    if (onClose) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="mt-6 rounded-lg border border-indigo-200 bg-white p-6 shadow-sm">
+      <div className="flex items-start justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Request access from your superadmin</h3>
+          <p className="mt-2 text-sm text-gray-600">
+            We couldn't find an account associated with{' '}
+            <span className="font-medium text-gray-900">{email || 'your email address'}</span>. Fill out the form below to
+            send a quick request for login credentials.
+          </p>
+        </div>
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-4 text-sm font-medium text-indigo-600 hover:text-indigo-500"
+          >
+            Close
+          </button>
+        )}
+      </div>
+
+      <form className="mt-4 space-y-4" onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="contact-name" className="block text-sm font-medium text-gray-700">
+            Your name
+          </label>
+          <input
+            id="contact-name"
+            name="name"
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            placeholder="Jane Doe"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="contact-notes" className="block text-sm font-medium text-gray-700">
+            Message to your superadmin (optional)
+          </label>
+          <textarea
+            id="contact-notes"
+            name="notes"
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            rows={4}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            placeholder="Let your superadmin know how they can help."
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="w-full rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        >
+          Open email to superadmin
+        </button>
+      </form>
+
+      <p className="mt-4 text-xs text-gray-500">
+        Prefer to reach out another way? Contact your superadmin directly at{' '}
+        <a className="font-medium text-indigo-600 hover:text-indigo-500" href={`mailto:${contactEmail}`}>
+          {contactEmail}
+        </a>
+        .
+      </p>
+    </div>
+  );
+};
+
+export default ContactSuperadminForm;


### PR DESCRIPTION
## Summary
- add explicit HTTP errors for unknown users and incorrect passwords with role-aware messaging
- propagate detailed login error information through the API service, auth context, and login page UI
- introduce a contact superadmin form that appears for unknown users so they can request credentials

## Testing
- npm run lint
- pytest *(fails: missing optional dependencies such as torch, requests, and pydantic in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c835e48530832a80ab494449e8d9d0