### PR TITLE
Enhance user management with group-aware roles

### DIFF
--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status
-from typing import List, Any
+from typing import List, Any, Optional
 from sqlalchemy.orm import Session
 from ... import models
 from ...schemas.user import User, UserCreate, UserUpdate, UserInDB, UserPasswordChange
@@ -49,6 +49,7 @@ async def create_user(
 @router.delete("/{user_id}", response_model=dict)
 async def delete_user(
     user_id: int,
+    replacement_admin_id: Optional[int] = None,
     user_service: UserService = Depends(get_user_service),
     current_user: models.User = Depends(get_current_active_user)
 ):
@@ -60,7 +61,7 @@ async def delete_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not enough permissions"
         )
-    return user_service.delete_user(user_id, current_user)
+    return user_service.delete_user(user_id, current_user, replacement_admin_id)
 
 @router.put("/{user_id}", response_model=User)
 async def update_user(

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -33,7 +33,8 @@ class UserBase(BaseModel):
     full_name: Optional[str] = None
     is_active: bool = True
     is_superuser: bool = False
-    roles: List[str] = []
+    group_id: Optional[int] = None
+    roles: List[str] = Field(default_factory=list)
 
     class Config:
         from_attributes = True  # Updated from orm_mode in Pydantic v2
@@ -123,6 +124,7 @@ class User(Base):
             "full_name": self.full_name,
             "is_active": self.is_active,
             "is_superuser": self.is_superuser,
+            "group_id": self.group_id,
             "roles": self.roles or [],
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,17 +1,21 @@
 from typing import Optional, List
-from pydantic import BaseModel, EmailStr, Field, validator
 from datetime import datetime
+from typing import List, Optional, Literal
+from pydantic import BaseModel, EmailStr, Field, validator
 
 class UserBase(BaseModel):
     """Base user schema with common fields."""
     username: str = Field(..., min_length=3, max_length=50, regex="^[a-zA-Z0-9_-]+$")
     email: EmailStr
     full_name: Optional[str] = Field(None, max_length=100)
+    group_id: Optional[int] = None
+    roles: List[str] = Field(default_factory=list)
 
 class UserCreate(UserBase):
     """Schema for creating a new user."""
     password: str = Field(default='Daybreak@2025', min_length=8, max_length=50)
     is_superuser: Optional[bool] = False
+    user_type: Optional[Literal['player', 'group_admin', 'system_admin']] = None
     
     @validator('password')
     def password_strength(cls, v):
@@ -27,16 +31,21 @@ class UserCreate(UserBase):
 
 class UserUpdate(BaseModel):
     """Schema for updating user information."""
+    username: Optional[str] = Field(None, min_length=3, max_length=50, regex="^[a-zA-Z0-9_-]+$")
     email: Optional[EmailStr] = None
     full_name: Optional[str] = Field(None, max_length=100)
     password: Optional[str] = Field(None, min_length=8, max_length=50)
     is_active: Optional[bool] = None
     is_superuser: Optional[bool] = None
+    group_id: Optional[int] = None
+    roles: Optional[List[str]] = None
+    user_type: Optional[Literal['player', 'group_admin', 'system_admin']] = None
 
 class UserInDBBase(UserBase):
     """Base schema for user data in the database."""
     id: int
     is_active: bool
+    is_superuser: bool
     created_at: datetime
     updated_at: datetime
     

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, Any
+from typing import Any, Dict, List, Optional
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 from fastapi import HTTPException, status
@@ -6,190 +6,538 @@ from .. import models
 from ..schemas import user as user_schemas
 from ..core.security import get_password_hash, verify_password
 
+
 class UserService:
+    """Service layer for user management."""
+
+    TYPE_ALIASES = {
+        "player": "player",
+        "players": "player",
+        "groupadmin": "group_admin",
+        "groupadministrator": "group_admin",
+        "admin": "group_admin",
+        "systemadmin": "system_admin",
+        "systemadministrator": "system_admin",
+        "superadmin": "system_admin",
+    }
+
+    TYPE_ROLE_MAP = {
+        "player": ["player"],
+        "group_admin": ["group_admin", "admin"],
+        "system_admin": ["system_admin"],
+    }
+
+    TYPE_ROLE_TOKENS = {"player", "groupadmin", "admin", "systemadmin", "superadmin"}
+
     def __init__(self, db: Session):
         self.db = db
 
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_token(value: Optional[str]) -> str:
+        if not value:
+            return ""
+        return "".join(ch for ch in str(value).lower() if ch.isalnum())
+
+    def _normalize_type(self, user_type: Optional[str]) -> Optional[str]:
+        if not user_type:
+            return None
+        token = self._normalize_token(user_type)
+        if token not in self.TYPE_ALIASES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid user type specified",
+            )
+        return self.TYPE_ALIASES[token]
+
+    def _normalized_roles(self, roles: Optional[List[str]]) -> List[str]:
+        return [
+            token
+            for role in roles or []
+            if (token := self._normalize_token(role))
+        ]
+
+    def _strip_type_roles(self, roles: Optional[List[str]]) -> List[str]:
+        cleaned: List[str] = []
+        for role in roles or []:
+            token = self._normalize_token(role)
+            if token in self.TYPE_ROLE_TOKENS:
+                continue
+            cleaned.append(role)
+        return cleaned
+
+    @staticmethod
+    def _dedupe_roles(roles: List[str]) -> List[str]:
+        seen = set()
+        deduped: List[str] = []
+        for role in roles:
+            if role is None:
+                continue
+            if not isinstance(role, str):
+                role = str(role)
+            if role not in seen:
+                deduped.append(role)
+                seen.add(role)
+        return deduped
+
+    def _resolve_user_type(
+        self,
+        user_type: Optional[str],
+        roles: Optional[List[str]],
+        is_superuser: Optional[bool],
+        existing_roles: Optional[List[str]],
+        default_is_superuser: bool,
+    ) -> str:
+        normalized_type = self._normalize_type(user_type)
+        if normalized_type:
+            return normalized_type
+
+        normalized_roles = set(self._normalized_roles(roles if roles is not None else existing_roles))
+        if is_superuser is True or default_is_superuser:
+            return "system_admin"
+        if "systemadmin" in normalized_roles or "superadmin" in normalized_roles:
+            return "system_admin"
+        if "groupadmin" in normalized_roles or "admin" in normalized_roles:
+            return "group_admin"
+        return "player"
+
+    def _normalize_group_id(self, group_id: Optional[Any]) -> Optional[int]:
+        if group_id is None:
+            return None
+        if isinstance(group_id, str):
+            stripped = group_id.strip()
+            if not stripped:
+                return None
+            if not stripped.isdigit():
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Invalid group id",
+                )
+            return int(stripped)
+        if isinstance(group_id, int):
+            return group_id
+        try:
+            return int(group_id)
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid group id",
+            )
+
+    def _validate_group_assignment(
+        self,
+        group_id: Optional[Any],
+        user_type: str,
+    ) -> (Optional[models.Group], Optional[int]):
+        normalized_group_id = self._normalize_group_id(group_id)
+        group: Optional[models.Group] = None
+        if normalized_group_id is not None:
+            group = self.db.query(models.Group).filter(models.Group.id == normalized_group_id).first()
+            if not group:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Group not found",
+                )
+
+        if user_type in {"player", "group_admin"} and group is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A group assignment is required for this user type",
+            )
+
+        return group, normalized_group_id
+
+    def _prepare_roles_for_type(
+        self,
+        base_roles: Optional[List[str]],
+        user_type: str,
+    ) -> List[str]:
+        roles = self._strip_type_roles(base_roles)
+        roles.extend(self.TYPE_ROLE_MAP[user_type])
+        return self._dedupe_roles(roles)
+
+    def _is_group_admin_user(self, user: models.User) -> bool:
+        if not user or not user.group_id:
+            return False
+        normalized_roles = set(self._normalized_roles(user.roles))
+        return "groupadmin" in normalized_roles or "admin" in normalized_roles
+
+    def _find_group_admins(
+        self,
+        group_id: Optional[int],
+        exclude_user_id: Optional[int] = None,
+    ) -> List[models.User]:
+        if not group_id:
+            return []
+        query = self.db.query(models.User).filter(models.User.group_id == group_id)
+        if exclude_user_id is not None:
+            query = query.filter(models.User.id != exclude_user_id)
+        users = query.all()
+        return [user for user in users if self._is_group_admin_user(user)]
+
+    def _find_all_group_admins(self, exclude_user_id: Optional[int] = None) -> List[models.User]:
+        query = self.db.query(models.User)
+        if exclude_user_id is not None:
+            query = query.filter(models.User.id != exclude_user_id)
+        users = query.all()
+        return [user for user in users if self._is_group_admin_user(user)]
+
+    def _cleanup_group_admin_on_delete(self, user: models.User) -> Dict[str, Any]:
+        if not self._is_group_admin_user(user):
+            return {
+                "group_deleted": False,
+                "group_id": user.group_id,
+                "group_name": None,
+            }
+
+        group = self.db.query(models.Group).filter(models.Group.id == user.group_id).first()
+        if not group:
+            return {
+                "group_deleted": False,
+                "group_id": user.group_id,
+                "group_name": None,
+            }
+
+        other_admins = self._find_group_admins(group.id, exclude_user_id=user.id)
+        if not other_admins:
+            group_name = group.name
+            self.db.delete(group)
+            return {
+                "group_deleted": True,
+                "group_id": group.id,
+                "group_name": group_name,
+            }
+
+        if group.admin_id == user.id:
+            group.admin_id = other_admins[0].id
+            self.db.add(group)
+
+        return {
+            "group_deleted": False,
+            "group_id": group.id,
+            "group_name": group.name,
+        }
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
     def get_user(self, user_id: int) -> models.User:
-        """Get a user by ID."""
         user = self.db.query(models.User).filter(models.User.id == user_id).first()
         if not user:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"User with ID {user_id} not found"
+                detail=f"User with ID {user_id} not found",
             )
         return user
 
     def get_user_by_email(self, email: str) -> Optional[models.User]:
-        """Get a user by email."""
         return self.db.query(models.User).filter(models.User.email == email).first()
 
     def get_user_by_username(self, username: str) -> Optional[models.User]:
-        """Get a user by username."""
         return self.db.query(models.User).filter(models.User.username == username).first()
 
     def get_users(self, skip: int = 0, limit: int = 100) -> List[models.User]:
-        """Get a list of users with pagination."""
         return self.db.query(models.User).offset(skip).limit(limit).all()
 
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
     def create_user(self, user: user_schemas.UserCreate) -> models.User:
-        """Create a new user."""
-        # Check if user with email already exists
-        db_user = self.get_user_by_email(user.email)
-        if db_user:
+        existing = self.get_user_by_email(user.email)
+        if existing:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Email already registered"
+                detail="Email already registered",
             )
-        
-        # Check if username is taken
-        db_user = self.get_user_by_username(user.username)
-        if db_user:
+
+        existing = self.get_user_by_username(user.username)
+        if existing:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Username already taken"
+                detail="Username already taken",
             )
-        
-        # Hash the password
+
+        desired_type = self._resolve_user_type(
+            user_type=user.user_type,
+            roles=user.roles,
+            is_superuser=user.is_superuser,
+            existing_roles=user.roles,
+            default_is_superuser=bool(user.is_superuser),
+        )
+
+        group, normalized_group_id = self._validate_group_assignment(user.group_id, desired_type)
+        roles = self._prepare_roles_for_type(user.roles, desired_type)
         hashed_password = get_password_hash(user.password)
-        
-        # Create new user
+
         db_user = models.User(
             username=user.username,
             email=user.email,
             hashed_password=hashed_password,
             full_name=user.full_name,
             is_active=True,
-            is_superuser=bool(user.is_superuser)
+            is_superuser=(desired_type == "system_admin"),
+            group_id=normalized_group_id,
+            roles=roles,
         )
-        
+
         try:
             self.db.add(db_user)
+            self.db.flush()
+
+            if desired_type == "group_admin" and group and (group.admin_id is None):
+                group.admin_id = db_user.id
+                self.db.add(group)
+
             self.db.commit()
             self.db.refresh(db_user)
             return db_user
-        except SQLAlchemyError as e:
+        except SQLAlchemyError:
             self.db.rollback()
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Error creating user"
+                detail="Error creating user",
             )
 
     def update_user(
-        self, 
-        user_id: int, 
+        self,
+        user_id: int,
         user_update: user_schemas.UserUpdate,
-        current_user: models.User
+        current_user: models.User,
     ) -> models.User:
-        """Update a user."""
-        # Only allow users to update their own account unless they're an admin
         if user_id != current_user.id and not current_user.is_superuser:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="Not enough permissions"
+                detail="Not enough permissions",
             )
-        
+
         db_user = self.get_user(user_id)
-        
-        # Update fields if they're provided
+
         if user_update.email is not None:
-            # Check if email is already taken
-            existing_user = self.get_user_by_email(user_update.email)
-            if existing_user and existing_user.id != user_id:
+            existing = self.get_user_by_email(user_update.email)
+            if existing and existing.id != user_id:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Email already registered"
+                    detail="Email already registered",
                 )
             db_user.email = user_update.email
-        
+
+        if user_update.username is not None:
+            existing = self.get_user_by_username(user_update.username)
+            if existing and existing.id != user_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Username already taken",
+                )
+            db_user.username = user_update.username
+
         if user_update.full_name is not None:
             db_user.full_name = user_update.full_name
-            
+
         if user_update.is_active is not None and current_user.is_superuser:
             db_user.is_active = user_update.is_active
-        if user_update.is_superuser is not None and current_user.is_superuser:
-            db_user.is_superuser = bool(user_update.is_superuser)
-        
+
+        previous_group_id = db_user.group_id
+        previous_type = self._resolve_user_type(
+            user_type=None,
+            roles=db_user.roles,
+            is_superuser=db_user.is_superuser,
+            existing_roles=db_user.roles,
+            default_is_superuser=db_user.is_superuser,
+        )
+
+        proposed_group_id = (
+            user_update.group_id
+            if user_update.group_id is not None
+            else db_user.group_id
+        )
+
+        desired_type = self._resolve_user_type(
+            user_type=user_update.user_type,
+            roles=user_update.roles if user_update.roles is not None else db_user.roles,
+            is_superuser=user_update.is_superuser,
+            existing_roles=db_user.roles,
+            default_is_superuser=user_update.is_superuser if user_update.is_superuser is not None else db_user.is_superuser,
+        )
+
+        group, normalized_group_id = self._validate_group_assignment(proposed_group_id, desired_type)
+
+        # Prevent removing the last group admin from a group via update
+        if previous_type == "group_admin":
+            changing_group = normalized_group_id != previous_group_id
+            losing_admin_role = desired_type != "group_admin"
+            if changing_group or losing_admin_role:
+                other_admins = self._find_group_admins(previous_group_id, exclude_user_id=db_user.id)
+                if not other_admins:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Cannot remove the last group admin from the group. Assign another group admin or delete the group first.",
+                    )
+                previous_group = self.db.query(models.Group).filter(models.Group.id == previous_group_id).first()
+                if previous_group and previous_group.admin_id == db_user.id:
+                    previous_group.admin_id = other_admins[0].id
+                    self.db.add(previous_group)
+
+        roles_source = user_update.roles if user_update.roles is not None else db_user.roles
+        roles = self._prepare_roles_for_type(roles_source, desired_type)
+
+        db_user.group_id = normalized_group_id
+        db_user.roles = roles
+        db_user.is_superuser = desired_type == "system_admin"
+
+        if user_update.password:
+            db_user.hashed_password = get_password_hash(user_update.password)
+
+        if desired_type == "group_admin" and group and (group.admin_id is None or group.admin_id == db_user.id):
+            group.admin_id = db_user.id
+            self.db.add(group)
+
         try:
             self.db.commit()
             self.db.refresh(db_user)
             return db_user
-        except SQLAlchemyError as e:
+        except SQLAlchemyError:
             self.db.rollback()
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Error updating user"
+                detail="Error updating user",
             )
 
-    def delete_user(self, user_id: int, current_user: models.User) -> Dict[str, Any]:
-        """Delete a user."""
-        # Only allow users to delete their own account unless they're an admin
+    def delete_user(
+        self,
+        user_id: int,
+        current_user: models.User,
+        replacement_admin_id: Optional[int] = None,
+    ) -> Dict[str, Any]:
         if user_id != current_user.id and not current_user.is_superuser:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="Not enough permissions"
+                detail="Not enough permissions",
             )
-        
+
         db_user = self.get_user(user_id)
-        
-        # Prevent deleting the last admin
-        if db_user.is_superuser:
-            admin_count = self.db.query(models.User).filter(
-                models.User.is_superuser == True,
-                models.User.is_active == True
-            ).count()
-            
-            if admin_count <= 1:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Cannot delete the last admin user"
-                )
-        
+        user_type = self._resolve_user_type(
+            user_type=None,
+            roles=db_user.roles,
+            is_superuser=db_user.is_superuser,
+            existing_roles=db_user.roles,
+            default_is_superuser=db_user.is_superuser,
+        )
+
+        promoted_user: Optional[models.User] = None
+
         try:
-            self.db.delete(db_user)
+            if user_type == "system_admin":
+                other_admins = self.db.query(models.User).filter(
+                    models.User.id != db_user.id,
+                    models.User.is_superuser == True,
+                    models.User.is_active == True,
+                ).count()
+
+                if other_admins == 0:
+                    if replacement_admin_id is None:
+                        candidates = self._find_all_group_admins(exclude_user_id=db_user.id)
+                        if not candidates:
+                            raise HTTPException(
+                                status_code=status.HTTP_400_BAD_REQUEST,
+                                detail={
+                                    "code": "no_group_admin_available",
+                                    "message": "Cannot delete the last system administrator. Create another system administrator first.",
+                                },
+                            )
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail={
+                                "code": "replacement_required",
+                                "message": "Select a group administrator to promote before deleting the last system administrator.",
+                                "candidates": [
+                                    {
+                                        "id": candidate.id,
+                                        "username": candidate.username,
+                                        "email": candidate.email,
+                                        "group_id": candidate.group_id,
+                                        "group_name": candidate.group.name if candidate.group else None,
+                                    }
+                                    for candidate in candidates
+                                ],
+                            },
+                        )
+
+                    replacement_user = self.get_user(replacement_admin_id)
+                    if replacement_user.id == db_user.id:
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Replacement user must be different from the user being deleted",
+                        )
+                    if not self._is_group_admin_user(replacement_user):
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Replacement user must be a group admin",
+                        )
+
+                    replacement_roles = list(replacement_user.roles or [])
+                    replacement_roles.append("system_admin")
+                    replacement_user.roles = self._dedupe_roles(replacement_roles)
+                    replacement_user.is_superuser = True
+                    self.db.add(replacement_user)
+                    promoted_user = replacement_user
+
+            group_cleanup = self._cleanup_group_admin_on_delete(db_user)
+
+            if not group_cleanup.get("group_deleted"):
+                self.db.delete(db_user)
             self.db.commit()
-            return {"message": "User deleted successfully"}
-        except SQLAlchemyError as e:
+
+            response: Dict[str, Any] = {"message": "User deleted successfully"}
+            response.update(group_cleanup)
+            if promoted_user:
+                response["replacement_promoted"] = {
+                    "id": promoted_user.id,
+                    "username": promoted_user.username,
+                    "email": promoted_user.email,
+                }
+            return response
+        except HTTPException:
+            self.db.rollback()
+            raise
+        except SQLAlchemyError:
             self.db.rollback()
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Error deleting user"
+                detail="Error deleting user",
             )
 
     def change_password(
-        self, 
-        user_id: int, 
-        current_password: str, 
+        self,
+        user_id: int,
+        current_password: str,
         new_password: str,
-        current_user: models.User
+        current_user: models.User,
     ) -> Dict[str, str]:
-        """Change a user's password."""
-        # Only allow users to change their own password unless they're an admin
         if user_id != current_user.id and not current_user.is_superuser:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="Not enough permissions"
+                detail="Not enough permissions",
             )
-        
+
         db_user = self.get_user(user_id)
-        
-        # If it's not an admin changing someone else's password, verify current password
+
         if not (current_user.is_superuser and user_id != current_user.id):
             if not verify_password(current_password, db_user.hashed_password):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Incorrect current password"
+                    detail="Incorrect current password",
                 )
-        
-        # Update password
+
         db_user.hashed_password = get_password_hash(new_password)
-        
+
         try:
             self.db.commit()
             return {"message": "Password updated successfully"}
-        except SQLAlchemyError as e:
+        except SQLAlchemyError:
             self.db.rollback()
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Error updating password"
+                detail="Error updating password",
             )

--- a/frontend/src/pages/admin/UserManagement.js
+++ b/frontend/src/pages/admin/UserManagement.js
@@ -1,105 +1,277 @@
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FaTrash, FaPlus, FaUserShield, FaUser, FaEdit } from 'react-icons/fa';
 import { toast } from 'react-toastify';
 import { useAuth } from '../../contexts/AuthContext';
-import { mixedGameApi } from '../../services/api';
+import { api, mixedGameApi } from '../../services/api';
+import { normalizeRoles } from '../../utils/authUtils';
+
+const USER_TYPE_OPTIONS = [
+  { value: 'player', label: 'Player' },
+  { value: 'group_admin', label: 'Group Admin' },
+  { value: 'system_admin', label: 'System Admin' },
+];
+
+const USER_TYPE_LABELS = {
+  player: 'Player',
+  group_admin: 'Group Admin',
+  system_admin: 'System Admin',
+};
+
+const DEFAULT_FORM = {
+  username: '',
+  email: '',
+  password: '',
+  userType: 'player',
+  groupId: '',
+};
+
+const DEFAULT_REPLACEMENT_PROMPT = {
+  open: false,
+  user: null,
+  options: [],
+  selected: '',
+  message: '',
+};
+
+const getUserType = (user) => {
+  if (!user) return 'player';
+  const normalizedRoles = normalizeRoles(user.roles || []);
+  if (user.is_superuser || normalizedRoles.includes('systemadmin')) {
+    return 'system_admin';
+  }
+  if (normalizedRoles.includes('groupadmin') || normalizedRoles.includes('admin')) {
+    return 'group_admin';
+  }
+  return 'player';
+};
+
+const getTypeBadgeClass = (type) => {
+  switch (type) {
+    case 'system_admin':
+      return 'bg-purple-100 text-purple-800';
+    case 'group_admin':
+      return 'bg-blue-100 text-blue-800';
+    default:
+      return 'bg-green-100 text-green-800';
+  }
+};
+
+const parseErrorMessage = (error, fallback) => {
+  const detail = error?.response?.data?.detail;
+  if (!detail) return fallback;
+  if (typeof detail === 'string') return detail;
+  if (typeof detail === 'object') {
+    return detail.message || fallback;
+  }
+  return fallback;
+};
 
 function UserManagement() {
   const [users, setUsers] = useState([]);
+  const [groups, setGroups] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showAddUser, setShowAddUser] = useState(false);
   const [editingUser, setEditingUser] = useState(null);
-  const [newUser, setNewUser] = useState({
-    username: '',
-    email: '',
-    password: '',
-    isSystemAdmin: false
-  });
+  const [form, setForm] = useState({ ...DEFAULT_FORM });
+  const [replacementPrompt, setReplacementPrompt] = useState({ ...DEFAULT_REPLACEMENT_PROMPT });
+
   const navigate = useNavigate();
   const { isGroupAdmin } = useAuth();
 
-  // Check if current user is admin
+  const groupMap = useMemo(() => {
+    const entries = (groups || []).map((group) => [group.id, group.name]);
+    return Object.fromEntries(entries);
+  }, [groups]);
+
+  const loadGroups = useCallback(async () => {
+    const response = await api.get('/groups');
+    setGroups(Array.isArray(response.data) ? response.data : []);
+  }, []);
+
+  const loadUsers = useCallback(async () => {
+    const response = await api.get('/auth/users/');
+    setUsers(Array.isArray(response.data) ? response.data : []);
+  }, []);
+
   useEffect(() => {
     if (!isGroupAdmin) {
       navigate('/unauthorized');
       return;
     }
-    fetchUsers();
-  }, [navigate, isGroupAdmin]);
 
-  const fetchUsers = async () => {
-    try {
-      // Admin list endpoint (cookie auth)
-      await mixedGameApi.health(); // quick health check to ensure API reachable
-      const res = await fetch('/api/v1/auth/users/', { credentials: 'include' });
-      if (!res.ok) throw new Error('Failed to fetch users');
-      const list = await res.json();
-      const normalized = (Array.isArray(list) ? list : []).map((user) => ({
-        ...user,
-        isSystemAdmin: Boolean(user.is_superuser),
-      }));
-      setUsers(normalized);
-    } catch (error) {
-      toast.error('Error loading users');
-      console.error('Error:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleDeleteUser = async (userId) => {
-    if (!window.confirm('Are you sure you want to delete this user?')) return;
-    
-    try {
-      // Delete endpoint may not be available on backend; show info
-      toast.info('User deletion is not enabled in this build.');
-    } catch (error) {
-      toast.error('Error deleting user');
-      console.error('Error:', error);
-    }
-  };
-
-  const handleAddUser = async (e) => {
-    e.preventDefault();
-
-    try {
-      if (editingUser) {
-        await fetch(`/api/v1/users/${editingUser.id}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({ username: newUser.username, email: newUser.email, is_superuser: newUser.isSystemAdmin })
-        });
-        toast.success('User updated');
-      } else {
-        await fetch('/api/v1/users/', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({ username: newUser.username, email: newUser.email, password: newUser.password, is_superuser: newUser.isSystemAdmin })
-        });
-        toast.success('User added');
+    const fetchAll = async () => {
+      setIsLoading(true);
+      try {
+        await mixedGameApi.health();
+        await Promise.all([loadGroups(), loadUsers()]);
+      } catch (error) {
+        console.error('Error loading user management data:', error);
+        toast.error('Failed to load user information');
+      } finally {
+        setIsLoading(false);
       }
-      fetchUsers();
-      setShowAddUser(false);
-      setEditingUser(null);
-    } catch (error) {
-      toast.error(error.message || 'Error saving user');
-      console.error('Error:', error);
-    }
+    };
+
+    fetchAll();
+  }, [isGroupAdmin, navigate, loadGroups, loadUsers]);
+
+  const handleOpenModal = () => {
+    setEditingUser(null);
+    setForm({ ...DEFAULT_FORM });
+    setShowAddUser(true);
+  };
+
+  const handleCloseModal = () => {
+    setShowAddUser(false);
+    setEditingUser(null);
+    setForm({ ...DEFAULT_FORM });
   };
 
   const handleEditUser = (user) => {
     setEditingUser(user);
-    setNewUser({ username: user.username, email: user.email, password: '', isSystemAdmin: user.isSystemAdmin });
+    setForm({
+      username: user.username || '',
+      email: user.email || '',
+      password: '',
+      userType: getUserType(user),
+      groupId: user.group_id ? String(user.group_id) : '',
+    });
     setShowAddUser(true);
+  };
+
+  const handleTypeChange = (value) => {
+    setForm((prev) => ({
+      ...prev,
+      userType: value,
+      groupId: value === 'system_admin' ? '' : prev.groupId,
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    const trimmedUsername = form.username.trim();
+    const trimmedEmail = form.email.trim();
+    const requiresGroup = form.userType !== 'system_admin';
+
+    if (!trimmedUsername || !trimmedEmail) {
+      toast.error('Username and email are required.');
+      return;
+    }
+
+    if (requiresGroup && !form.groupId) {
+      toast.error('Please select a group for this user.');
+      return;
+    }
+
+    const payload = {
+      username: trimmedUsername,
+      email: trimmedEmail,
+      user_type: form.userType,
+      group_id: requiresGroup ? Number(form.groupId) : null,
+    };
+
+    if (!editingUser || form.password) {
+      if (!editingUser && !form.password) {
+        toast.error('Password is required for new users.');
+        return;
+      }
+      payload.password = form.password;
+    }
+
+    try {
+      if (editingUser) {
+        await api.put(`/users/${editingUser.id}`, payload);
+        toast.success('User updated');
+      } else {
+        await api.post('/users/', payload);
+        toast.success('User created');
+      }
+
+      handleCloseModal();
+      try {
+        await Promise.all([loadUsers(), loadGroups()]);
+      } catch (refreshError) {
+        console.error('Error refreshing user list:', refreshError);
+        toast.error('User saved, but the list could not be refreshed.');
+      }
+    } catch (error) {
+      const message = parseErrorMessage(error, 'Failed to save user');
+      toast.error(message);
+    }
+  };
+
+  const handleDeleteUser = async (user) => {
+    if (!user) return;
+    const confirmMessage = `Are you sure you want to delete ${user.username || 'this user'}?`;
+    if (!window.confirm(confirmMessage)) return;
+
+    try {
+      await api.delete(`/users/${user.id}`);
+      toast.success('User deleted');
+      try {
+        await Promise.all([loadUsers(), loadGroups()]);
+      } catch (refreshError) {
+        console.error('Error refreshing user list:', refreshError);
+        toast.error('User deleted, but the list could not be refreshed.');
+      }
+    } catch (error) {
+      const detail = error?.response?.data?.detail;
+      if (detail && typeof detail === 'object' && detail.code === 'replacement_required') {
+        setReplacementPrompt({
+          open: true,
+          user,
+          options: Array.isArray(detail.candidates) ? detail.candidates : [],
+          selected: '',
+          message: detail.message || 'Select a group admin to promote before deleting this system admin.',
+        });
+        return;
+      }
+
+      if (detail && typeof detail === 'object' && detail.code === 'no_group_admin_available') {
+        toast.error(detail.message || 'Cannot delete the last system admin without another admin.');
+        return;
+      }
+
+      const message = parseErrorMessage(error, 'Failed to delete user');
+      toast.error(message);
+    }
+  };
+
+  const closeReplacementPrompt = () => {
+    setReplacementPrompt({ ...DEFAULT_REPLACEMENT_PROMPT });
+  };
+
+  const handleConfirmReplacement = async () => {
+    if (!replacementPrompt.user) return;
+    if (!replacementPrompt.selected) {
+      toast.error('Please select a replacement system admin.');
+      return;
+    }
+
+    try {
+      await api.delete(`/users/${replacementPrompt.user.id}`, {
+        params: { replacement_admin_id: replacementPrompt.selected },
+      });
+      toast.success('User deleted and replacement promoted to system admin');
+      closeReplacementPrompt();
+      try {
+        await Promise.all([loadUsers(), loadGroups()]);
+      } catch (refreshError) {
+        console.error('Error refreshing user list:', refreshError);
+        toast.error('Changes applied, but the list could not be refreshed.');
+      }
+    } catch (error) {
+      const message = parseErrorMessage(error, 'Failed to delete user');
+      toast.error(message);
+    }
   };
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500" />
       </div>
     );
   }
@@ -109,80 +281,111 @@ function UserManagement() {
       <div className="flex justify-between items-center mb-8">
         <h1 className="text-3xl font-bold text-gray-800">User Management</h1>
         <button
-          onClick={() => { setEditingUser(null); setNewUser({ username: '', email: '', password: '', isSystemAdmin: false }); setShowAddUser(true); }}
+          onClick={handleOpenModal}
           className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center"
         >
           <FaPlus className="mr-2" /> Add User
         </button>
       </div>
 
-      {/* Add User Modal */}
       {showAddUser && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 w-full max-w-md">
+          <div className="bg-white rounded-lg p-6 w-full max-w-lg">
             <div className="flex justify-between items-center mb-4">
-            <h2 className="text-xl font-semibold">{editingUser ? 'Edit User' : 'Add New User'}</h2>
-              <button 
-                onClick={() => { setShowAddUser(false); setEditingUser(null); }}
-                className="text-gray-500 hover:text-gray-700"
-              >
+              <h2 className="text-xl font-semibold">{editingUser ? 'Edit User' : 'Add New User'}</h2>
+              <button onClick={handleCloseModal} className="text-gray-500 hover:text-gray-700">
                 ✕
               </button>
             </div>
-            
-            <form onSubmit={handleAddUser} className="space-y-4">
+
+            <form onSubmit={handleSubmit} className="space-y-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Username</label>
                 <input
                   type="text"
-                  value={newUser.username}
-                  onChange={(e) => setNewUser({...newUser, username: e.target.value})}
+                  value={form.username}
+                  onChange={(event) => setForm((prev) => ({ ...prev, username: event.target.value }))}
                   className="w-full px-3 py-2 border border-gray-300 rounded-md"
                   required
                 />
               </div>
-              
+
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
                 <input
                   type="email"
-                  value={newUser.email}
-                  onChange={(e) => setNewUser({...newUser, email: e.target.value})}
+                  value={form.email}
+                  onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
                   className="w-full px-3 py-2 border border-gray-300 rounded-md"
                   required
                 />
               </div>
-              
-              {!editingUser && (
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Password {editingUser ? '(leave blank to keep current)' : ''}
+                </label>
+                <input
+                  type="password"
+                  value={form.password}
+                  onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  required={!editingUser}
+                />
+              </div>
+
+              <div>
+                <span className="block text-sm font-medium text-gray-700 mb-2">User Type</span>
+                <div className="flex flex-wrap gap-3">
+                  {USER_TYPE_OPTIONS.map((option) => (
+                    <label
+                      key={option.value}
+                      className={`flex items-center gap-2 px-3 py-2 border rounded-md cursor-pointer ${
+                        form.userType === option.value ? 'border-blue-500 bg-blue-50' : 'border-gray-300'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="userType"
+                        value={option.value}
+                        checked={form.userType === option.value}
+                        onChange={() => handleTypeChange(option.value)}
+                        className="h-4 w-4"
+                      />
+                      <span className="text-sm font-medium text-gray-700">{option.label}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              {form.userType !== 'system_admin' && (
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
-                  <input
-                    type="password"
-                    value={newUser.password}
-                    onChange={(e) => setNewUser({...newUser, password: e.target.value})}
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Group</label>
+                  <select
+                    value={form.groupId}
+                    onChange={(event) => setForm((prev) => ({ ...prev, groupId: event.target.value }))}
                     className="w-full px-3 py-2 border border-gray-300 rounded-md"
                     required
-                  />
+                  >
+                    <option value="">Select a group</option>
+                    {groups.map((group) => (
+                      <option key={group.id} value={group.id}>
+                        {group.name}
+                      </option>
+                    ))}
+                  </select>
+                  {groups.length === 0 && (
+                    <p className="text-xs text-red-600 mt-1">
+                      No groups available. Create a group before adding players or group admins.
+                    </p>
+                  )}
                 </div>
               )}
-              
-              <div className="flex items-center">
-                <input
-                  type="checkbox"
-                  id="isSystemAdmin"
-                  checked={newUser.isSystemAdmin}
-                  onChange={(e) => setNewUser({...newUser, isSystemAdmin: e.target.checked})}
-                  className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                />
-                <label htmlFor="isSystemAdmin" className="ml-2 block text-sm text-gray-700">
-                  System Administrator
-                </label>
-              </div>
-              
+
               <div className="flex justify-end space-x-3 pt-4">
                 <button
                   type="button"
-                onClick={() => { setShowAddUser(false); setEditingUser(null); }}
+                  onClick={handleCloseModal}
                   className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50"
                 >
                   Cancel
@@ -199,7 +402,6 @@ function UserManagement() {
         </div>
       )}
 
-      {/* Users Table */}
       <div className="table-surface overflow-hidden sm:rounded-lg">
         <div className="overflow-x-auto">
           <table className="min-w-full divide-y divide-gray-200">
@@ -212,7 +414,10 @@ function UserManagement() {
                   Email
                 </th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Role
+                  Group
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Type
                 </th>
                 <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Actions
@@ -220,56 +425,103 @@ function UserManagement() {
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {users.map((user) => (
-                <tr key={user.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center">
-                      <div className="flex-shrink-0 h-10 w-10 rounded-full bg-blue-100 flex items-center justify-center">
-                        {user.isSystemAdmin ? (
-                          <FaUserShield className="h-5 w-5 text-blue-600" />
-                        ) : (
-                          <FaUser className="h-5 w-5 text-gray-400" />
-                        )}
+              {users.map((user) => {
+                const type = getUserType(user);
+                return (
+                  <tr key={user.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="flex items-center">
+                        <div className="flex-shrink-0 h-10 w-10 rounded-full bg-blue-100 flex items-center justify-center">
+                          {type === 'system_admin' ? (
+                            <FaUserShield className="h-5 w-5 text-blue-600" />
+                          ) : (
+                            <FaUser className="h-5 w-5 text-gray-400" />
+                          )}
+                        </div>
+                        <div className="ml-4">
+                          <div className="text-sm font-medium text-gray-900">{user.username}</div>
+                        </div>
                       </div>
-                      <div className="ml-4">
-                        <div className="text-sm font-medium text-gray-900">{user.username}</div>
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {user.email}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${user.isSystemAdmin ? 'bg-purple-100 text-purple-800' : 'bg-green-100 text-green-800'}`}>
-                      {user.isSystemAdmin ? 'System Admin' : 'User'}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                    {user.email !== 'systemadmin@daybreak.ai' && (
-                      <>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{user.email}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {groupMap[user.group_id] || '—'}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${getTypeBadgeClass(type)}`}>
+                        {USER_TYPE_LABELS[type] || 'User'}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                      <div className="flex items-center justify-end space-x-3">
                         <button
                           onClick={() => handleEditUser(user)}
-                          className="text-blue-600 hover:text-blue-900 mr-3"
+                          className="text-blue-600 hover:text-blue-900"
                           title="Edit User"
                         >
                           <FaEdit />
                         </button>
                         <button
-                          onClick={() => handleDeleteUser(user.id)}
+                          onClick={() => handleDeleteUser(user)}
                           className="text-red-600 hover:text-red-900"
                           title="Delete User"
                         >
                           <FaTrash />
                         </button>
-                      </>
-                    )}
-                  </td>
-                </tr>
-              ))}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
       </div>
+
+      {replacementPrompt.open && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 w-full max-w-md">
+            <h3 className="text-lg font-semibold mb-4">Promote a Group Admin</h3>
+            <p className="text-sm text-gray-700 mb-3">
+              {replacementPrompt.message || 'Select a group admin to promote to system admin before deleting this user.'}
+            </p>
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 mb-1">Replacement System Admin</label>
+              <select
+                value={replacementPrompt.selected}
+                onChange={(event) =>
+                  setReplacementPrompt((prev) => ({ ...prev, selected: event.target.value }))
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              >
+                <option value="">Select a group admin</option>
+                {replacementPrompt.options.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.username || option.email}
+                    {option.group_name ? ` — ${option.group_name}` : ''}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex justify-end space-x-3">
+              <button
+                type="button"
+                onClick={closeReplacementPrompt}
+                className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmReplacement}
+                className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+              >
+                Promote &amp; Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- extend the admin user management view with user type selection, group dropdowns, and last-system-admin replacement prompts
- update user schemas and service logic to honor user types, manage group admin reassignment/deletion, and promote replacements when removing the final system admin
- allow the delete user endpoint to accept an optional replacement admin id

## Testing
- npm run lint
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c86b4fa36c832a816a7db1128e998a