### PR TITLE
Create dedicated system admin user management

### DIFF
--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -15,8 +15,9 @@ def get_user_service(db: Session = Depends(get_db)) -> UserService:
 
 @router.get("/", response_model=List[User])
 async def read_users(
-    skip: int = 0, 
+    skip: int = 0,
     limit: int = 100,
+    user_type: Optional[str] = None,
     user_service: UserService = Depends(get_user_service),
     current_user: models.User = Depends(get_current_active_user)
 ):
@@ -27,6 +28,7 @@ async def read_users(
         current_user=current_user,
         skip=skip,
         limit=limit,
+        user_type=user_type,
     )
 
 @router.post("/", response_model=User, status_code=status.HTTP_201_CREATED)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,7 @@ import AdminTraining from "./pages/admin/Training.jsx";
 import ModelSetup from "./pages/admin/ModelSetup.jsx";
 import Users from "./pages/Users";
 import AdminUserManagement from "./pages/admin/UserManagement.js";
+import SystemAdminUserManagement from "./pages/admin/SystemAdminUserManagement.jsx";
 import GroupManagement from "./pages/admin/GroupManagement.jsx";
 import Settings from "./pages/Settings";
 import SystemConfig from "./pages/SystemConfig.jsx";
@@ -188,6 +189,16 @@ const AppContent = () => {
                   <Navbar />
                   <Box sx={(theme) => theme.mixins.toolbar} />
                   <AdminUserManagement />
+                </>
+              }
+            />
+            <Route
+              path="/system/users"
+              element={
+                <>
+                  <Navbar />
+                  <Box sx={(theme) => theme.mixins.toolbar} />
+                  <SystemAdminUserManagement />
                 </>
               }
             />

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -133,10 +133,10 @@ const Navbar = ({ handleDrawerToggle }) => {
               <Button
                 color="inherit"
                 startIcon={<GroupIcon />}
-                onClick={() => navigate('/admin/users')}
+                onClick={() => navigate('/system/users')}
                 sx={{
                   mx: 1,
-                  bgcolor: isActive('/admin/users') ? 'rgba(255, 255, 255, 0.1)' : 'transparent',
+                  bgcolor: isActive('/system/users') ? 'rgba(255, 255, 255, 0.1)' : 'transparent',
                   '&:hover': {
                     bgcolor: 'rgba(255, 255, 255, 0.15)'
                   }

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -61,7 +61,7 @@ const groupAdminMenuItems = [
 const systemAdminMenuItems = [
   { text: 'System Config', icon: <SettingsIcon />, path: '/system-config' },
   { text: 'Group Management', icon: <GroupsIcon />, path: '/admin/groups' },
-  { text: 'User Management', icon: <UsersIcon />, path: '/admin/users' },
+  { text: 'User Management', icon: <UsersIcon />, path: '/system/users' },
 ];
 
 const Sidebar = ({ mobileOpen, handleDrawerToggle }) => {

--- a/frontend/src/components/supply-chain-config/SupplyChainConfigList.jsx
+++ b/frontend/src/components/supply-chain-config/SupplyChainConfigList.jsx
@@ -1,18 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { 
-  Box, 
-  Button, 
-  Card, 
-  CardContent, 
-  CardHeader, 
-  Divider,
-  IconButton,
-  List,
-  ListItem,
-  Tooltip,
-  Typography,
-
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
   Chip,
   CircularProgress,
   Dialog,
@@ -20,7 +13,10 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Divider,
   IconButton,
+  List,
+  ListItem,
   Menu,
   MenuItem,
   Paper,
@@ -63,6 +59,15 @@ const SupplyChainConfigList = ({
 
   const navigate = useNavigate();
   const { enqueueSnackbar } = useSnackbar();
+
+  const formatDate = (value) => {
+    if (!value) return '—';
+    try {
+      return format(new Date(value), 'MMM d, yyyy');
+    } catch (error) {
+      return value;
+    }
+  };
 
   const fetchConfigs = async () => {
     try {


### PR DESCRIPTION
## Summary
- update the users API to accept an optional user_type filter and limit system administrators to creating, updating, or deleting group admin accounts
- rebuild the group admin player management screen and add a new system administrator user management page with corresponding route and navigation updates
- tidy supply chain configuration list imports and add a shared date formatter helper

## Testing
- npm run lint
- pytest *(fails: missing torch/requests/pydantic in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c88d27ff2c832aaa647bc58233a6ce