### PR TITLE
Limit group admin SC configs to own group

### DIFF
--- a/frontend/src/pages/admin/GroupSupplyChainConfigForm.jsx
+++ b/frontend/src/pages/admin/GroupSupplyChainConfigForm.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { Box, CircularProgress } from '@mui/material';
+import { Alert, Box, CircularProgress } from '@mui/material';
 import { useAuth } from '../../contexts/AuthContext';
 import { isGroupAdmin as isGroupAdminUser } from '../../utils/authUtils';
 import SupplyChainConfigForm from '../../components/supply-chain-config/SupplyChainConfigForm';
@@ -21,11 +21,23 @@ const GroupSupplyChainConfigForm = () => {
     return <Navigate to="/unauthorized" replace />;
   }
 
+  const groupId = user?.group_id ?? null;
+
+  if (isGroupAdminUser(user) && !groupId) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="50vh">
+        <Alert severity="warning">
+          You must be assigned to a group before you can create or edit supply chain configurations.
+        </Alert>
+      </Box>
+    );
+  }
+
   return (
     <SupplyChainConfigForm
       basePath="/admin/group/supply-chain-configs"
       allowGroupSelection={false}
-      defaultGroupId={user?.group_id ?? null}
+      defaultGroupId={groupId}
     />
   );
 };

--- a/frontend/src/pages/admin/GroupSupplyChainConfigList.jsx
+++ b/frontend/src/pages/admin/GroupSupplyChainConfigList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { Box, CircularProgress } from '@mui/material';
+import { Alert, Box, CircularProgress } from '@mui/material';
 import { useAuth } from '../../contexts/AuthContext';
 import { isGroupAdmin as isGroupAdminUser } from '../../utils/authUtils';
 import SupplyChainConfigList from '../../components/supply-chain-config/SupplyChainConfigList';
@@ -21,10 +21,23 @@ const GroupSupplyChainConfigList = () => {
     return <Navigate to="/unauthorized" replace />;
   }
 
+  const restrictToGroupId = user?.group_id ?? null;
+
+  if (isGroupAdminUser(user) && !restrictToGroupId) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="50vh">
+        <Alert severity="warning">
+          You must be assigned to a group before you can manage supply chain configurations.
+        </Alert>
+      </Box>
+    );
+  }
+
   return (
     <SupplyChainConfigList
       title="My Group's Supply Chain Configurations"
       basePath="/admin/group/supply-chain-configs"
+      restrictToGroupId={restrictToGroupId}
     />
   );
 };


### PR DESCRIPTION
## Summary
- ensure the shared supply chain config list can optionally filter to a specific group and surface fetch errors
- guard the group admin supply chain config pages so they only operate on the admin's group and warn when no group is assigned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c896e5e384832a8946c886d6453fe0