### PR TITLE
Fix login redirect loop to root

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -28,7 +28,7 @@ import GroupSupplyChainConfigList from "./pages/admin/GroupSupplyChainConfigList
 import GroupSupplyChainConfigForm from "./pages/admin/GroupSupplyChainConfigForm.jsx";
 import Players from "./pages/Players.jsx";
 import DebugBanner from "./components/DebugBanner.jsx";
-import { getDefaultLandingPath } from "./utils/authUtils";
+import { buildLoginRedirectPath, getDefaultLandingPath } from "./utils/authUtils";
 
 window.onerror = function (message, source, lineno, colno, error) {
   console.error("Global error:", { message, source, lineno, colno, error });
@@ -51,8 +51,7 @@ function RequireAuth() {
   }
 
   if (!isAuthenticated) {
-    const back = encodeURIComponent(location.pathname + location.search);
-    return <Navigate to={`/login?redirect=${back}`} replace />;
+    return <Navigate to={buildLoginRedirectPath(location)} replace />;
   }
 
   return <Outlet />;

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { Box, CircularProgress } from '@mui/material';
+import { buildLoginRedirectPath } from '../utils/authUtils';
 
 // Unified ProtectedRoute with optional role checks and children support
 function ProtectedRoute({ children, allowedRoles = [] }) {
@@ -17,8 +18,7 @@ function ProtectedRoute({ children, allowedRoles = [] }) {
   }
 
   if (!isAuthenticated) {
-    const back = encodeURIComponent(location.pathname + location.search);
-    return <Navigate to={`/login?redirect=${back}`} replace />;
+    return <Navigate to={buildLoginRedirectPath(location)} replace />;
   }
 
   if (allowedRoles.length > 0 && !hasAnyRole(allowedRoles)) {

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { mixedGameApi } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
+import { buildLoginRedirectPath } from '../utils/authUtils';
 
 const Register = () => {
   const [formData, setFormData] = useState({
@@ -110,7 +111,8 @@ const Register = () => {
         // Auto-redirect to login after a delay
         setTimeout(() => {
           const redirectTo = searchParams.get('redirect') || '/';
-          navigate(`/login?redirect=${encodeURIComponent(redirectTo)}`);
+          const loginPath = buildLoginRedirectPath(redirectTo);
+          navigate(loginPath);
         }, 5000);
       } else {
         throw new Error(error || 'Registration failed. Please try again.');

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,6 +1,7 @@
 // /frontend/src/services/api.js
 import axios from "axios";
 import { API_BASE_URL } from "../config/api";
+import { buildLoginRedirectPath } from "../utils/authUtils";
 
 // Create a single axios instance for the app
 const http = axios.create({
@@ -53,8 +54,11 @@ http.interceptors.response.use(
       } catch (refreshError) {
         // If refresh fails, go to login only once
         if (window.location.pathname !== '/login') {
-          const returnTo = encodeURIComponent(window.location.pathname + window.location.search);
-          window.location.replace(`/login?redirect=${returnTo}`);
+          const loginPath = buildLoginRedirectPath({
+            pathname: window.location.pathname,
+            search: window.location.search,
+          });
+          window.location.replace(loginPath);
         }
         return Promise.reject(refreshError);
       }

--- a/frontend/src/utils/authUtils.js
+++ b/frontend/src/utils/authUtils.js
@@ -67,3 +67,39 @@ export const getDefaultLandingPath = (user) => {
 
   return '/dashboard';
 };
+
+/**
+ * Builds the appropriate login URL for redirecting an unauthenticated user.
+ * Avoids appending a redirect back to the root route (`/`) so that the
+ * application doesn't appear to "recycle" to `/login?redirect=%2F` on first
+ * load. Accepts either a React Router location object or a path string.
+ */
+export const buildLoginRedirectPath = (locationLike) => {
+  if (!locationLike) {
+    return '/login';
+  }
+
+  let pathname = '/';
+  let search = '';
+
+  if (typeof locationLike === 'string') {
+    const withoutHash = locationLike.split('#')[0] || '/';
+    const [pathPart, searchPart] = withoutHash.split('?');
+    pathname = pathPart.startsWith('/') ? pathPart : `/${pathPart}`;
+    search = searchPart ? `?${searchPart}` : '';
+  } else {
+    pathname = locationLike.pathname || '/';
+    search = locationLike.search || '';
+  }
+
+  pathname = pathname.startsWith('/') ? pathname : `/${pathname}`;
+
+  const shouldIncludeRedirect = !(pathname === '/' && !search);
+
+  if (!shouldIncludeRedirect) {
+    return '/login';
+  }
+
+  const target = `${pathname}${search}`;
+  return `/login?redirect=${encodeURIComponent(target)}`;
+};

--- a/frontend/src/utils/fetchInterceptor.js
+++ b/frontend/src/utils/fetchInterceptor.js
@@ -1,3 +1,5 @@
+import { buildLoginRedirectPath } from './authUtils';
+
 // Save the original fetch
 const nativeFetch = window.fetch;
 
@@ -20,8 +22,11 @@ window.fetch = async function(input, init = {}) {
     // Avoid redirect loops if we're already on the login page
     const isLoginPage = window.location.pathname.startsWith('/login');
     if (response.status === 401 && !isAuth && !isLoginPage) {
-      const back = encodeURIComponent(window.location.pathname + window.location.search);
-      window.location.replace(`/login?redirect=${back}`);
+      const loginPath = buildLoginRedirectPath({
+        pathname: window.location.pathname,
+        search: window.location.search,
+      });
+      window.location.replace(loginPath);
       return new Response(null, { status: 401, statusText: 'Unauthorized' });
     }
 


### PR DESCRIPTION
## Summary
- avoid generating login redirects back to `/` so the app no longer lands on `/login?redirect=%2F`
- centralize login redirect URL construction and reuse it across auth guards and interceptors

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68c8c17ff3b4832aaf71a250c4268b40