### PR TITLE
Add admin group edit and delete modals

### DIFF
--- a/backend/app/services/group_service.py
+++ b/backend/app/services/group_service.py
@@ -156,11 +156,33 @@ class GroupService:
             self.db.add(game)
             self.db.flush()
 
+            group_suffix = f"g{group.id}"
+            player_password_hash = get_password_hash("Daybreak@2025")
             default_users = [
-                {"username": "retailer", "email": "retailer@daybreak.ai", "full_name": "Retailer", "role": PlayerRole.RETAILER},
-                {"username": "distributor", "email": "distributor@daybreak.ai", "full_name": "Distributor", "role": PlayerRole.DISTRIBUTOR},
-                {"username": "manufacturer", "email": "manufacturer@daybreak.ai", "full_name": "Manufacturer", "role": PlayerRole.MANUFACTURER},
-                {"username": "supplier", "email": "supplier@daybreak.ai", "full_name": "Supplier", "role": PlayerRole.WHOLESALER},
+                {
+                    "username": f"retailer_{group_suffix}",
+                    "email": f"retailer+{group_suffix}@daybreak.ai",
+                    "full_name": "Retailer",
+                    "role": PlayerRole.RETAILER,
+                },
+                {
+                    "username": f"distributor_{group_suffix}",
+                    "email": f"distributor+{group_suffix}@daybreak.ai",
+                    "full_name": "Distributor",
+                    "role": PlayerRole.DISTRIBUTOR,
+                },
+                {
+                    "username": f"manufacturer_{group_suffix}",
+                    "email": f"manufacturer+{group_suffix}@daybreak.ai",
+                    "full_name": "Manufacturer",
+                    "role": PlayerRole.MANUFACTURER,
+                },
+                {
+                    "username": f"supplier_{group_suffix}",
+                    "email": f"supplier+{group_suffix}@daybreak.ai",
+                    "full_name": "Supplier",
+                    "role": PlayerRole.WHOLESALER,
+                },
             ]
 
             player_users = []
@@ -169,7 +191,7 @@ class GroupService:
                     username=spec["username"],
                     email=spec["email"],
                     full_name=spec["full_name"],
-                    hashed_password=get_password_hash("Daybreak@2025"),
+                    hashed_password=player_password_hash,
                     roles=["player"],
                     group_id=group.id,
                     is_active=True,


### PR DESCRIPTION
## Summary
- add edit and delete controls on the system admin group management page with modal workflows and pre-populated admin fields when editing
- add a confirmation modal for group deletion that blocks while the request is in flight and refreshes the list when complete

## Testing
- npm run lint
- pytest *(fails: missing torch/requests/pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c7b6d7f0832a9750d4b4e6385bee