### PR TITLE
Fix supply chain admin API integration and add form helper

### DIFF
--- a/backend/app/models/supply_chain_config.py
+++ b/backend/app/models/supply_chain_config.py
@@ -46,6 +46,13 @@ class SupplyChainConfig(Base):
     market_demands = relationship("MarketDemand", back_populates="config", cascade="all, delete-orphan")
     group = relationship("Group", back_populates="supply_chain_configs")
 
+    # Training metadata
+    needs_training = Column(Boolean, nullable=False, default=True)
+    training_status = Column(String(50), nullable=False, default="pending")
+    trained_at = Column(DateTime, nullable=True)
+    trained_model_path = Column(String(255), nullable=True)
+    last_trained_config_hash = Column(String(128), nullable=True)
+
 class Item(Base):
     """Products in the supply chain"""
     __tablename__ = "items"

--- a/backend/app/schemas/supply_chain_config.py
+++ b/backend/app/schemas/supply_chain_config.py
@@ -169,6 +169,23 @@ class SupplyChainConfig(SupplyChainConfigBase):
     id: int
     created_at: datetime
     updated_at: datetime
+    needs_training: bool = Field(True, description="Whether the configuration requires retraining")
+    training_status: Optional[str] = Field(
+        None,
+        description="Human-readable status for the most recent training job",
+    )
+    trained_at: Optional[datetime] = Field(
+        None,
+        description="Timestamp of the last successful training run",
+    )
+    trained_model_path: Optional[str] = Field(
+        None,
+        description="Filesystem path to the most recent trained model",
+    )
+    last_trained_config_hash: Optional[str] = Field(
+        None,
+        description="Hash of the configuration when it was last trained",
+    )
     items: List[Item] = []
     nodes: List[Node] = []
     lanes: List[Lane] = []

--- a/backend/migrations/versions/20240920160000_add_training_metadata_to_supply_chain_config.py
+++ b/backend/migrations/versions/20240920160000_add_training_metadata_to_supply_chain_config.py
@@ -1,0 +1,48 @@
+"""Add training metadata columns to supply chain configs
+
+Revision ID: 20240920160000
+Revises: 20240915120000
+Create Date: 2025-09-20 16:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '20240920160000'
+down_revision = '20240915120000'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'supply_chain_configs',
+        sa.Column('needs_training', sa.Boolean(), nullable=False, server_default=sa.text('1')),
+    )
+    op.add_column(
+        'supply_chain_configs',
+        sa.Column('training_status', sa.String(length=50), nullable=False, server_default='pending'),
+    )
+    op.add_column('supply_chain_configs', sa.Column('trained_at', sa.DateTime(), nullable=True))
+    op.add_column(
+        'supply_chain_configs',
+        sa.Column('trained_model_path', sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        'supply_chain_configs',
+        sa.Column('last_trained_config_hash', sa.String(length=128), nullable=True),
+    )
+
+    # Remove server defaults now that existing rows have been initialised
+    op.alter_column('supply_chain_configs', 'needs_training', server_default=None)
+    op.alter_column('supply_chain_configs', 'training_status', server_default=None)
+
+
+def downgrade():
+    op.drop_column('supply_chain_configs', 'last_trained_config_hash')
+    op.drop_column('supply_chain_configs', 'trained_model_path')
+    op.drop_column('supply_chain_configs', 'trained_at')
+    op.drop_column('supply_chain_configs', 'training_status')
+    op.drop_column('supply_chain_configs', 'needs_training')

--- a/frontend/src/components/admin/AgentConfigForm.jsx
+++ b/frontend/src/components/admin/AgentConfigForm.jsx
@@ -16,9 +16,8 @@ import {
   Divider
 } from '@mui/material';
 import { Save, Delete } from '@mui/icons-material';
-import { useFormik } from 'formik';
-import * as Yup from 'yup';
-import api from '../../services/api';
+import { useFormik } from '../../hooks/useFormik';
+import { api } from '../../services/api';
 
 const agentTypes = [
   { value: 'base', label: 'Base Agent' },
@@ -26,18 +25,19 @@ const agentTypes = [
   { value: 'reinforcement_learning', label: 'Reinforcement Learning' },
 ];
 
-const validationSchema = Yup.object({
-  role: Yup.string().required('Required'),
-  agent_type: Yup.string().required('Required'),
-  config: Yup.object().test(
-    'config-validation',
-    'Invalid configuration',
-    function(value) {
-      // Add specific validation based on agent_type if needed
-      return true;
-    }
-  )
-});
+const validate = (values) => {
+  const errors = {};
+
+  if (!values.role) {
+    errors.role = 'Required';
+  }
+
+  if (!values.agent_type) {
+    errors.agent_type = 'Required';
+  }
+
+  return errors;
+};
 
 const AgentConfigForm = ({ gameId, configId, onSuccess }) => {
   const [loading, setLoading] = useState(!!configId);
@@ -50,7 +50,7 @@ const AgentConfigForm = ({ gameId, configId, onSuccess }) => {
       agent_type: 'base',
       config: {}
     },
-    validationSchema,
+    validate,
     onSubmit: async (values) => {
       try {
         setError(null);
@@ -60,9 +60,9 @@ const AgentConfigForm = ({ gameId, configId, onSuccess }) => {
         };
         
         if (configId) {
-          await api.put(`/api/agent-configs/${configId}`, data);
+          await api.put(`/agent-configs/${configId}`, data);
         } else {
-          await api.post('/api/agent-configs', data);
+          await api.post('/agent-configs', data);
         }
         
         if (onSuccess) onSuccess();
@@ -77,12 +77,12 @@ const AgentConfigForm = ({ gameId, configId, onSuccess }) => {
     const fetchData = async () => {
       try {
         // Fetch available roles
-        const rolesRes = await api.get(`/api/games/${gameId}/available-roles`);
+        const rolesRes = await api.get(`/games/${gameId}/available-roles`);
         setAvailableRoles(rolesRes.data);
 
         // If editing, load the config
         if (configId) {
-          const configRes = await api.get(`/api/agent-configs/${configId}`);
+          const configRes = await api.get(`/agent-configs/${configId}`);
           formik.setValues(configRes.data);
         }
       } catch (err) {
@@ -264,7 +264,7 @@ const AgentConfigForm = ({ gameId, configId, onSuccess }) => {
                     onClick={async () => {
                       if (window.confirm('Are you sure you want to delete this configuration?')) {
                         try {
-                          await api.delete(`/api/agent-configs/${configId}`);
+                          await api.delete(`/agent-configs/${configId}`);
                           if (onSuccess) onSuccess();
                         } catch (err) {
                           setError('Failed to delete configuration');

--- a/frontend/src/components/admin/AgentConfigs.jsx
+++ b/frontend/src/components/admin/AgentConfigs.jsx
@@ -20,7 +20,7 @@ import {
   Alert
 } from '@mui/material';
 import { Add as AddIcon, Edit as EditIcon, Delete as DeleteIcon } from '@mui/icons-material';
-import api from '../../services/api';
+import { api } from '../../services/api';
 import AgentConfigForm from './AgentConfigForm';
 
 const AgentConfigs = ({ gameId }) => {
@@ -33,7 +33,7 @@ const AgentConfigs = ({ gameId }) => {
   const fetchConfigs = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await api.get(`/api/games/${gameId}/agent-configs`);
+      const response = await api.get(`/games/${gameId}/agent-configs`);
       setConfigs(response.data);
       setError(null);
     } catch (err) {
@@ -51,7 +51,7 @@ const AgentConfigs = ({ gameId }) => {
   const handleDelete = async (id) => {
     if (window.confirm('Are you sure you want to delete this configuration?')) {
       try {
-        await api.delete(`/api/agent-configs/${id}`);
+        await api.delete(`/agent-configs/${id}`);
         setConfigs(configs.filter(config => config.id !== id));
       } catch (err) {
         setError('Failed to delete configuration');

--- a/frontend/src/components/admin/RoleAssignment.jsx
+++ b/frontend/src/components/admin/RoleAssignment.jsx
@@ -14,7 +14,7 @@ import {
   Alert,
   Button
 } from '@mui/material';
-import api from '../../services/api';
+import { api } from '../../services/api';
 
 const RoleAssignment = ({ gameId }) => {
   const [roles, setRoles] = useState([]);
@@ -30,19 +30,19 @@ const RoleAssignment = ({ gameId }) => {
       try {
         setLoading(true);
         // Fetch available roles
-        const rolesRes = await api.get(`/api/games/${gameId}/available-roles`);
+        const rolesRes = await api.get(`/games/${gameId}/available-roles`);
         setRoles(rolesRes.data);
 
         // Fetch current assignments
-        const assignmentsRes = await api.get(`/api/games/${gameId}/roles`);
+        const assignmentsRes = await api.get(`/games/${gameId}/roles`);
         setAssignments(assignmentsRes.data);
 
         // Fetch agent configs
-        const configsRes = await api.get(`/api/games/${gameId}/agent-configs`);
+        const configsRes = await api.get(`/games/${gameId}/agent-configs`);
         setAgentConfigs(configsRes.data);
 
         // Fetch users (you'll need to implement this endpoint)
-        const usersRes = await api.get(`/api/games/${gameId}/users`);
+        const usersRes = await api.get(`/games/${gameId}/users`);
         setUsers(usersRes.data);
 
         setLoading(false);
@@ -74,7 +74,7 @@ const RoleAssignment = ({ gameId }) => {
       // Update each role assignment
       for (const [role, assignment] of Object.entries(assignments)) {
         updates.push(
-          api.put(`/api/games/${gameId}/roles/${role}`, assignment)
+          api.put(`/games/${gameId}/roles/${role}`, assignment)
         );
       }
       

--- a/frontend/src/components/supply-chain-config/SupplyChainConfigForm.jsx
+++ b/frontend/src/components/supply-chain-config/SupplyChainConfigForm.jsx
@@ -29,10 +29,9 @@ import {
   Save as SaveIcon,
   ArrowBack as ArrowBackIcon
 } from '@mui/icons-material';
-import { useFormik } from 'formik';
-import * as Yup from 'yup';
+import { useFormik } from '../../hooks/useFormik';
 import { useSnackbar } from 'notistack';
-import api from '../../services/api';
+import { api } from '../../services/api';
 
 // Import services
 import {
@@ -108,6 +107,22 @@ const SupplyChainConfigForm = ({
   const [groupsError, setGroupsError] = useState(null);
 
   // Formik form
+  const validateForm = useCallback((values) => {
+    const errors = {};
+    if (!values.name || !values.name.trim()) {
+      errors.name = 'Name is required';
+    }
+
+    if (allowGroupSelection) {
+      const groupValue = values.group_id ?? '';
+      if (!String(groupValue).trim()) {
+        errors.group_id = 'Group is required';
+      }
+    }
+
+    return errors;
+  }, [allowGroupSelection]);
+
   const formik = useFormik({
     initialValues: {
       name: '',
@@ -115,14 +130,7 @@ const SupplyChainConfigForm = ({
       is_active: false,
       group_id: defaultGroupId ? String(defaultGroupId) : '',
     },
-    validationSchema: Yup.object({
-      name: Yup.string().required('Name is required'),
-      description: Yup.string(),
-      is_active: Yup.boolean(),
-      ...(allowGroupSelection
-        ? { group_id: Yup.string().required('Group is required') }
-        : {}),
-    }),
+    validate: validateForm,
     onSubmit: async (values) => {
       try {
         setLoading(true);
@@ -171,7 +179,7 @@ const SupplyChainConfigForm = ({
     const loadGroups = async () => {
       try {
         setGroupsLoading(true);
-        const response = await api.get('/api/v1/groups');
+        const response = await api.get('/groups');
         if (!isMounted) return;
         setGroups(response.data || []);
         setGroupsError(null);

--- a/frontend/src/components/supply-chain-config/SupplyChainConfigList.jsx
+++ b/frontend/src/components/supply-chain-config/SupplyChainConfigList.jsx
@@ -38,15 +38,21 @@ import {
   ContentCopy as CopyIcon,
   MoreVert as MoreVertIcon,
   SportsEsports as GameIcon,
+  PlayArrow as TrainIcon,
+  HourglassBottom as InProgressIcon,
+  ErrorOutline as ErrorIcon,
+  CheckCircleOutline as TrainedIcon,
 } from '@mui/icons-material';
 import { useSnackbar } from 'notistack';
 import { format } from 'date-fns';
-import api from '../../services/api';
+import { api } from '../../services/api';
+import { trainSupplyChainConfig } from '../../services/supplyChainConfigService';
 
 const SupplyChainConfigList = ({
   title = 'Supply Chain Configurations',
   basePath = '/supply-chain-config',
   restrictToGroupId = null,
+  enableTraining = false,
 } = {}) => {
 
   const [configs, setConfigs] = useState([]);
@@ -57,6 +63,7 @@ const SupplyChainConfigList = ({
   const [anchorEl, setAnchorEl] = useState(null);
   const [selectedConfig, setSelectedConfig] = useState(null);
   const [activatingConfig, setActivatingConfig] = useState(null);
+  const [trainingStatus, setTrainingStatus] = useState({});
 
   const navigate = useNavigate();
   const { enqueueSnackbar } = useSnackbar();
@@ -70,10 +77,92 @@ const SupplyChainConfigList = ({
     }
   };
 
+  const normalizedStatus = (config) => String(config?.training_status || '').toLowerCase();
+
+  const isTrainingActive = (config) => {
+    if (!config) return false;
+    if (trainingStatus[config.id]?.inProgress) return true;
+    return normalizedStatus(config) === 'in_progress';
+  };
+
+  const canTrainConfig = (config) => {
+    if (!enableTraining || !config) return false;
+    if (isTrainingActive(config)) return false;
+    const status = normalizedStatus(config);
+    if (config.needs_training) return true;
+    if (status === 'failed' || status === 'error') return true;
+    return false;
+  };
+
+  const renderTrainingChip = (config) => {
+    const status = normalizedStatus(config);
+    let trainedAt = null;
+    if (config?.trained_at) {
+      try {
+        trainedAt = format(new Date(config.trained_at), 'MMM d, yyyy HH:mm');
+      } catch (err) {
+        trainedAt = null;
+      }
+    }
+
+    if (trainingStatus[config?.id]?.inProgress || status === 'in_progress') {
+      return (
+        <Chip
+          icon={<InProgressIcon />}
+          label="Training…"
+          color="info"
+          size="small"
+        />
+      );
+    }
+
+    if (config?.needs_training) {
+      return (
+        <Chip
+          icon={<InProgressIcon />}
+          label="Needs training"
+          color="warning"
+          size="small"
+        />
+      );
+    }
+
+    if (status === 'failed' || status === 'error') {
+      return (
+        <Chip
+          icon={<ErrorIcon />}
+          label="Training failed"
+          color="error"
+          size="small"
+        />
+      );
+    }
+
+    if (status === 'trained' || status === 'complete' || !config?.needs_training) {
+      return (
+        <Chip
+          icon={<TrainedIcon />}
+          label={trainedAt ? `Trained • ${trainedAt}` : 'Trained'}
+          color="success"
+          size="small"
+        />
+      );
+    }
+
+    return (
+      <Chip
+        icon={<InProgressIcon />}
+        label={status ? status.replace(/_/g, ' ') : 'Status unknown'}
+        color="default"
+        size="small"
+      />
+    );
+  };
+
   const fetchConfigs = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await api.get('/api/v1/supply-chain-config');
+      const response = await api.get('/supply-chain-config');
       const data = response.data || [];
       const targetGroupId =
         restrictToGroupId !== null && restrictToGroupId !== undefined
@@ -122,7 +211,7 @@ const SupplyChainConfigList = ({
     if (!configToDelete) return;
 
     try {
-      await api.delete(`/api/v1/supply-chain-config/${configToDelete.id}`);
+      await api.delete(`/supply-chain-config/${configToDelete.id}`);
       enqueueSnackbar('Configuration deleted successfully', { variant: 'success' });
       await fetchConfigs();
     } catch (err) {
@@ -156,7 +245,7 @@ const SupplyChainConfigList = ({
 
     try {
       setActivatingConfig(configId);
-      await api.put(`/api/v1/supply-chain-config/${configId}`, { is_active: true });
+      await api.put(`/supply-chain-config/${configId}`, { is_active: true });
       enqueueSnackbar('Configuration activated successfully', { variant: 'success' });
       await fetchConfigs();
     } catch (err) {
@@ -173,7 +262,7 @@ const SupplyChainConfigList = ({
 
     try {
       const { id, created_at, updated_at, is_active, ...configData } = config;
-      await api.post('/api/v1/supply-chain-config', {
+      await api.post('/supply-chain-config', {
         ...configData,
         group_id: config.group_id ?? configData.group_id ?? null,
         name: `${config.name} (Copy)`,
@@ -189,11 +278,30 @@ const SupplyChainConfigList = ({
     }
   };
 
+  const handleTrainConfig = async (config) => {
+    if (!config || !enableTraining) return;
+    const configId = config.id;
+    setTrainingStatus((prev) => ({ ...prev, [configId]: { inProgress: true } }));
+
+    try {
+      const response = await trainSupplyChainConfig(configId, {});
+      const message = response?.message || 'Training completed successfully';
+      enqueueSnackbar(message, { variant: 'success' });
+    } catch (err) {
+      const detail = err?.response?.data?.detail || err?.message || 'Failed to train configuration';
+      enqueueSnackbar(detail, { variant: 'error' });
+    } finally {
+      setTrainingStatus((prev) => ({ ...prev, [configId]: { inProgress: false } }));
+      await fetchConfigs();
+      handleMenuClose();
+    }
+  };
+
   const renderTableBody = () => {
     if (configs.length === 0) {
       return (
         <TableRow>
-          <TableCell colSpan={6} align="center">
+          <TableCell colSpan={enableTraining ? 7 : 6} align="center">
             {loading ? (
               <CircularProgress size={24} />
             ) : (
@@ -248,6 +356,9 @@ const SupplyChainConfigList = ({
             </TableCell>
             <TableCell>{formatDate(config.created_at)}</TableCell>
             <TableCell>{formatDate(config.updated_at)}</TableCell>
+            {enableTraining && (
+              <TableCell>{renderTrainingChip(config)}</TableCell>
+            )}
             <TableCell align="right">
               <Tooltip title="Edit">
                 <IconButton size="small" onClick={() => handleEdit(config.id)}>
@@ -276,7 +387,7 @@ const SupplyChainConfigList = ({
         ))}
         {loading && (
           <TableRow>
-            <TableCell colSpan={6} align="center">
+            <TableCell colSpan={enableTraining ? 7 : 6} align="center">
               <CircularProgress size={20} />
             </TableCell>
           </TableRow>
@@ -341,6 +452,9 @@ const SupplyChainConfigList = ({
                               sx={{ ml: 1 }}
                               icon={<ActiveIcon />}
                             />
+                          )}
+                          {enableTraining && (
+                            <Box ml={1}>{renderTrainingChip(config)}</Box>
                           )}
                         </Box>
                         <Typography variant="body2" color="textSecondary">
@@ -413,6 +527,7 @@ const SupplyChainConfigList = ({
                 <TableCell>Status</TableCell>
                 <TableCell>Created</TableCell>
                 <TableCell>Updated</TableCell>
+                {enableTraining && <TableCell>Training</TableCell>}
                 <TableCell align="right">Actions</TableCell>
               </TableRow>
             </TableHead>
@@ -432,6 +547,23 @@ const SupplyChainConfigList = ({
         >
           <EditIcon sx={{ mr: 1 }} fontSize="small" /> Edit
         </MenuItem>
+        {enableTraining && (
+          <MenuItem
+            onClick={() => {
+              if (selectedConfig) {
+                handleTrainConfig(selectedConfig);
+              }
+            }}
+            disabled={!canTrainConfig(selectedConfig)}
+          >
+            {isTrainingActive(selectedConfig) || trainingStatus[selectedConfig?.id]?.inProgress ? (
+              <CircularProgress size={20} sx={{ mr: 1 }} />
+            ) : (
+              <TrainIcon sx={{ mr: 1 }} fontSize="small" />
+            )}
+            Train
+          </MenuItem>
+        )}
         <MenuItem onClick={handleCreateGame}>
           <GameIcon sx={{ mr: 1 }} fontSize="small" /> Create Game
         </MenuItem>

--- a/frontend/src/hooks/useFormik.js
+++ b/frontend/src/hooks/useFormik.js
@@ -1,0 +1,123 @@
+import { useCallback, useRef, useState } from 'react';
+
+const cloneValues = (values) => ({ ...(values ?? {}) });
+
+const runValidator = (validate, values, setErrors) => {
+  if (typeof validate !== 'function') {
+    setErrors({});
+    return {};
+  }
+
+  const result = validate(values) || {};
+  setErrors(result);
+  return result;
+};
+
+const useFormik = ({ initialValues = {}, validate, onSubmit }) => {
+  const [values, setValuesState] = useState(() => cloneValues(initialValues));
+  const [errors, setErrors] = useState({});
+  const [touched, setTouched] = useState({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const valuesRef = useRef(values);
+
+  const updateValues = useCallback((updater, shouldValidate = true) => {
+    setValuesState((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : cloneValues(updater);
+      valuesRef.current = next;
+      if (shouldValidate) {
+        runValidator(validate, next, setErrors);
+      }
+      return next;
+    });
+  }, [validate]);
+
+  const setValues = useCallback((nextValues, shouldValidate = true) => {
+    updateValues(nextValues, shouldValidate);
+  }, [updateValues]);
+
+  const setFieldValue = useCallback((field, value, shouldValidate = true) => {
+    updateValues((prev) => ({ ...(prev ?? {}), [field]: value }), shouldValidate);
+  }, [updateValues]);
+
+  const handleChange = useCallback((eventOrPath, maybeValue) => {
+    if (typeof eventOrPath === 'string') {
+      setFieldValue(eventOrPath, maybeValue, true);
+      return;
+    }
+
+    const event = eventOrPath;
+    const target = event?.target;
+    if (!target?.name) {
+      return;
+    }
+
+    const { name, type, checked, value } = target;
+    const resolvedValue = type === 'checkbox' ? checked : value;
+    setFieldValue(name, resolvedValue, true);
+  }, [setFieldValue]);
+
+  const handleBlur = useCallback((event) => {
+    const target = event?.target;
+    if (!target?.name) {
+      return;
+    }
+
+    const { name } = target;
+    setTouched((prev) => ({ ...(prev ?? {}), [name]: true }));
+    runValidator(validate, valuesRef.current, setErrors);
+  }, [validate]);
+
+  const markAllTouched = useCallback(() => {
+    const current = valuesRef.current || {};
+    const entries = Object.keys(current).reduce((acc, key) => {
+      acc[key] = true;
+      return acc;
+    }, {});
+    setTouched((prev) => ({ ...(prev ?? {}), ...entries }));
+  }, []);
+
+  const handleSubmit = useCallback(async (event) => {
+    if (event?.preventDefault) {
+      event.preventDefault();
+    }
+
+    markAllTouched();
+
+    const current = valuesRef.current || {};
+    const validationErrors = runValidator(validate, current, setErrors);
+    if (Object.keys(validationErrors).length > 0) {
+      return validationErrors;
+    }
+
+    if (typeof onSubmit !== 'function') {
+      return {};
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(current);
+    } finally {
+      setIsSubmitting(false);
+    }
+
+    return {};
+  }, [markAllTouched, onSubmit, validate]);
+
+  const submitForm = useCallback(() => handleSubmit(), [handleSubmit]);
+
+  return {
+    values,
+    errors,
+    touched,
+    isSubmitting,
+    handleChange,
+    handleBlur,
+    handleSubmit,
+    submitForm,
+    setFieldValue,
+    setValues,
+  };
+};
+
+export { useFormik };
+export default useFormik;

--- a/frontend/src/pages/SystemConfig.jsx
+++ b/frontend/src/pages/SystemConfig.jsx
@@ -80,7 +80,7 @@ export default function SystemConfig() {
       }
   
       try {
-        const res = await api.get('/api/v1/supply-chain-config');
+        const res = await api.get('/supply-chain-config');
         const list = res.data || [];
         setConfigs(list);
         const match = list.find((cfg) => cfg.name === cfgName);

--- a/frontend/src/pages/admin/Dashboard.jsx
+++ b/frontend/src/pages/admin/Dashboard.jsx
@@ -1,1171 +1,156 @@
-import { useEffect, useState, useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  CircularProgress,
+  Paper,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
+import StorageIcon from '@mui/icons-material/Storage';
+import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
+import GroupIcon from '@mui/icons-material/Group';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import { Navigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
-import {
-  Chart as ChartJS,
-  CategoryScale,
-  LinearScale,
-  LineElement,
-  PointElement,
-  Title,
-  Tooltip,
-  Legend,
-  ArcElement,
-} from 'chart.js';
-import { Line, Pie } from 'react-chartjs-2';
-import {
-  UsersIcon,
-  ClockIcon,
-  ChartBarIcon,
-  UserGroupIcon,
-  CogIcon,
-  ShieldCheckIcon,
-  DocumentTextIcon,
-  UserCircleIcon,
-} from '@heroicons/react/24/outline';
+import { isSystemAdmin as isSystemAdminUser } from '../../utils/authUtils';
+import GroupSupplyChainConfigList from './GroupSupplyChainConfigList';
+import GroupPlayerManagement from './UserManagement';
+import GroupGameConfigPanel from './GroupGameConfigPanel';
+import GroupGameSupervisionPanel from './GroupGameSupervisionPanel';
 import { mixedGameApi } from '../../services/api';
 
-const ROLE_DISPLAY_LABELS = {
-  retailer: 'Retailer',
-  wholesaler: 'Wholesaler',
-  distributor: 'Distributor',
-  factory: 'Factory',
-  manufacturer: 'Manufacturer',
-  supervisor: 'Supervisor',
-};
-
-const normalizeRoleKey = (role) => {
-  if (role === null || role === undefined) {
-    return '';
-  }
-  const rawValue =
-    typeof role === 'string'
-      ? role
-      : role?.value !== undefined
-      ? role.value
-      : role?.name !== undefined
-      ? role.name
-      : role;
-  return String(rawValue).toLowerCase();
-};
-
-const formatRoleLabel = (roleKey) => {
-  if (!roleKey) {
-    return 'Player';
-  }
-  const normalized = roleKey.toLowerCase();
-  if (ROLE_DISPLAY_LABELS[normalized]) {
-    return ROLE_DISPLAY_LABELS[normalized];
-  }
-  return normalized
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-};
-
-const splitReasonLines = (text) => {
-  if (!text) {
-    return [];
-  }
-  return text
-    .replace(/\r?\n/g, ' | ')
-    .split(/\s*\|\s*/g)
-    .map((part) => part.trim())
-    .filter(Boolean);
-};
-
-const parseReasonSections = (comment) => {
-  if (!comment) {
-    return { agent: '', supervisor: '' };
-  }
-  const text = String(comment).trim();
-  if (!text) {
-    return { agent: '', supervisor: '' };
-  }
-  const idx = text.toLowerCase().indexOf('supervisor (week');
-  if (idx === -1) {
-    return { agent: text, supervisor: '' };
-  }
-  const agent = text.slice(0, idx).trim();
-  const supervisor = text.slice(idx).trim();
-  return { agent, supervisor };
-};
-
-const toNumberOrNull = (value) => {
-  if (value === null || value === undefined) {
-    return null;
-  }
-  if (typeof value === 'number') {
-    return Number.isFinite(value) ? value : null;
-  }
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-};
-
-const buildReasoningTableData = (gameId, gameName, players = [], rounds = []) => {
-  const playersById = new Map();
-  const roleMeta = new Map();
-
-  let hasSupervisor = players.some((player) => {
-    const strategyRaw = player?.strategy ?? player?.ai_strategy;
-    if (!strategyRaw) {
-      return false;
-    }
-    const strategyValue = strategyRaw?.value ?? strategyRaw?.name ?? strategyRaw;
-    return String(strategyValue).toUpperCase() === 'DAYBREAK_DTCE_CENTRAL';
-  });
-
-  players.forEach((player) => {
-    if (!player) return;
-    const roleKey = normalizeRoleKey(player.role);
-    if (!roleKey) return;
-    playersById.set(player.id, { ...player, roleKey });
-    if (!roleMeta.has(roleKey)) {
-      roleMeta.set(roleKey, {
-        key: roleKey,
-        label: formatRoleLabel(roleKey),
-      });
-    }
-  });
-
-  const priorityOrder = ['retailer', 'wholesaler', 'distributor', 'manufacturer', 'factory'];
-  const orderedRoles = [];
-  priorityOrder.forEach((roleKey) => {
-    if (roleMeta.has(roleKey)) {
-      orderedRoles.push(roleMeta.get(roleKey));
-      roleMeta.delete(roleKey);
-    }
-  });
-  roleMeta.forEach((meta) => {
-    orderedRoles.push(meta);
-  });
-
-  const sortedRounds = Array.isArray(rounds)
-    ? [...rounds].sort((a, b) => {
-        const aWeek = Number(a?.round_number ?? a?.week ?? a?.number ?? 0);
-        const bWeek = Number(b?.round_number ?? b?.week ?? b?.number ?? 0);
-        return aWeek - bWeek;
-      })
-    : [];
-
-  const rows = sortedRounds.map((round) => {
-    const week = Number(round?.round_number ?? round?.week ?? round?.number ?? 0);
-    const roleEntries = {};
-    const supervisorEntries = {};
-    const playerRounds = Array.isArray(round?.player_rounds) ? round.player_rounds : [];
-
-    playerRounds.forEach((playerRound) => {
-      if (!playerRound) return;
-      const player = playersById.get(playerRound.player_id);
-      if (!player) return;
-
-      const { agent, supervisor } = parseReasonSections(playerRound.comment);
-      const orderValue = toNumberOrNull(playerRound.order_placed);
-      const inventoryValue = toNumberOrNull(
-        playerRound.inventory_after ?? playerRound.inventory_before
-      );
-      const backlogValue = toNumberOrNull(
-        playerRound.backorders_after ?? playerRound.backorders_before
-      );
-
-      roleEntries[player.roleKey] = {
-        order: orderValue,
-        inventory: inventoryValue,
-        backlog: backlogValue,
-        reason: agent,
-        lines: splitReasonLines(agent),
-      };
-
-      if (supervisor) {
-        const existing = supervisorEntries[player.roleKey];
-        const combinedText = existing ? `${existing.reason}\n${supervisor}` : supervisor;
-        supervisorEntries[player.roleKey] = {
-          reason: combinedText,
-          lines: splitReasonLines(combinedText),
-        };
-        hasSupervisor = true;
-      }
-    });
-
-    return {
-      week,
-      roles: roleEntries,
-      supervisor: Object.keys(supervisorEntries).length ? supervisorEntries : null,
-    };
-  });
-
-  return {
-    gameId,
-    gameName,
-    roles: orderedRoles,
-    rows,
-    hasSupervisor,
-  };
-};
-
-ChartJS.register(CategoryScale, LinearScale, LineElement, PointElement, Title, Tooltip, Legend, ArcElement);
-
-const StatCard = ({ title, value, icon: Icon, change, changeType = 'neutral', loading = false }) => (
-  <div className="card-surface overflow-hidden rounded-lg">
-    <div className="pad-6">
-      <div className="flex items-center">
-        <div className="flex-shrink-0 bg-indigo-500 rounded-md p-3">
-          <Icon className="h-6 w-6 text-white" aria-hidden="true" />
-        </div>
-        <div className="ml-5 w-0 flex-1">
-          <dt className="text-sm font-medium text-gray-500 truncate">{title}</dt>
-          {loading ? (
-            <dd className="animate-pulse h-7 bg-gray-200 rounded w-3/4"></dd>
-          ) : (
-            <dd className="flex items-baseline">
-              <div className="text-2xl font-semibold text-gray-900">{value}</div>
-              {typeof change === 'number' && (
-                <div
-                  className={`ml-2 flex items-baseline text-sm font-medium ${
-                    changeType === 'increase' ? 'text-green-600' : changeType === 'decrease' ? 'text-red-600' : 'text-gray-500'
-                  }`}
-                >
-                  {changeType === 'increase' ? <span className="text-green-500">↑</span> : changeType === 'decrease' ? <span className="text-red-500">↓</span> : null}
-                  <span className="ml-1">{change}%</span>
-                </div>
-              )}
-            </dd>
-          )}
-        </div>
-      </div>
-    </div>
-  </div>
-);
-
-const UserStatusBadge = ({ status }) => {
-  const statusMap = {
-    active: { text: 'Active', color: 'bg-green-100 text-green-800' },
-    inactive: { text: 'Inactive', color: 'bg-yellow-100 text-yellow-800' },
-    suspended: { text: 'Suspended', color: 'bg-red-100 text-red-800' },
-    pending: { text: 'Pending', color: 'bg-blue-100 text-blue-800' },
-  };
-  const key = typeof status === 'string' ? status.toLowerCase() : 'pending';
-  const statusInfo = statusMap[key] || { text: String(status ?? 'Unknown'), color: 'bg-gray-100 text-gray-800' };
-  return <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${statusInfo.color}`}>{statusInfo.text}</span>;
-};
-
-const GameStatusBadge = ({ status }) => {
-  const statusMap = {
-    completed: { text: 'Completed', color: 'bg-green-100 text-green-800' },
-    in_progress: { text: 'In Progress', color: 'bg-blue-100 text-blue-800' },
-    abandoned: { text: 'Abandoned', color: 'bg-red-100 text-red-800' },
-    waiting: { text: 'Waiting', color: 'bg-yellow-100 text-yellow-800' },
-  };
-  const statusInfo = statusMap[status] || { text: status, color: 'bg-gray-100 text-gray-800' };
-  return <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${statusInfo.color}`}>{statusInfo.text}</span>;
-};
-
-const RangesModal = ({ visible, rangeEdits, onClose, onChange, onSave, originalConfig }) => {
-  if (!visible) return null;
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-3xl">
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
-          <h4 className="text-base font-semibold">Edit System Ranges</h4>
-          <button className="text-gray-500 hover:text-gray-700" onClick={onClose}>✕</button>
-        </div>
-        <div className="p-4 max-h-[70vh] overflow-auto">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {Object.entries(rangeEdits || {}).map(([k, rng]) => {
-              const orig = (originalConfig || {})[k] || {};
-              const changed = rng?.min !== orig?.min || rng?.max !== orig?.max;
-              const invalid = Number.isFinite(rng?.min) && Number.isFinite(rng?.max) && rng.min > rng.max;
-              return (
-                <div key={k} className={`rounded border ${invalid ? 'border-red-300 bg-red-50' : changed ? 'border-yellow-300 bg-yellow-50' : 'border-gray-200 bg-gray-50'} p-3`}>
-                  <div className="text-sm text-gray-700 mb-2 capitalize">{k.replaceAll('_', ' ')}</div>
-                  <div className="flex items-center space-x-2">
-                    <div className="flex-1">
-                      <label className="block text-xs text-gray-500 mb-1">Min</label>
-                      <input type="number" className="w-full border border-gray-300 rounded px-2 py-1 text-sm" value={rng.min} onChange={(e) => onChange(k, { ...rng, min: e.target.valueAsNumber })} />
-                    </div>
-                    <div className="flex-1">
-                      <label className="block text-xs text-gray-500 mb-1">Max</label>
-                      <input type="number" className="w-full border border-gray-300 rounded px-2 py-1 text-sm" value={rng.max} onChange={(e) => onChange(k, { ...rng, max: e.target.valueAsNumber })} />
-                    </div>
-                  </div>
-                  {invalid && <div className="mt-1 text-xs text-red-600">Min must be ≤ Max</div>}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-        <div className="px-4 py-3 border-t border-gray-200 flex justify-end space-x-2">
-          <button className="text-gray-600 hover:text-gray-800 text-sm" onClick={onClose}>Cancel</button>
-          <button className="text-white bg-indigo-600 px-3 py-1 rounded text-sm disabled:opacity-50" disabled={Object.values(rangeEdits || {}).some((r) => (r?.min ?? 0) > (r?.max ?? 0))} onClick={onSave}>
-            Save
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-};
+const tabItems = [
+  { value: 'sc', label: 'SC Config', icon: <StorageIcon fontSize="small" /> },
+  { value: 'game', label: 'Game Config', icon: <SportsEsportsIcon fontSize="small" /> },
+  { value: 'users', label: 'User Config', icon: <GroupIcon fontSize="small" /> },
+  { value: 'supervision', label: 'Game Supervision', icon: <VisibilityIcon fontSize="small" /> },
+];
 
 const AdminDashboard = () => {
-  const auth = useAuth();
-  const { isGroupAdmin, user } = auth;
-  const navigate = useNavigate();
-  const location = useLocation();
-  const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
-  const selectedGameId = params.get('gameId') || '';
+  const { user, loading, isGroupAdmin } = useAuth();
+  const isSystemAdmin = isSystemAdminUser(user);
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [activeTab, setActiveTab] = useState('overview');
+  const initialTab = searchParams.get('section') || 'sc';
+  const [activeTab, setActiveTab] = useState(tabItems.some((tab) => tab.value === initialTab) ? initialTab : 'sc');
 
-  const [stats, setStats] = useState(null);
-  const [recentUsers, setRecentUsers] = useState([]);
-  const [recentGames, setRecentGames] = useState([]);
-  const [gameConfigs, setGameConfigs] = useState({});
-
-  const [showRangesModal, setShowRangesModal] = useState(false);
-  const [rangeEdits, setRangeEdits] = useState({});
-
-  const [reasoningData, setReasoningData] = useState({
-    gameId: null,
-    gameName: '',
-    roles: [],
-    rows: [],
-    hasSupervisor: false,
-  });
-  const [reasoningLoading, setReasoningLoading] = useState(false);
-  const [reasoningError, setReasoningError] = useState(null);
-  const [reasoningFocus, setReasoningFocus] = useState('all');
-  const [myGames, setMyGames] = useState([]);
-
-  const activeGameProgress = useMemo(() => {
-    if (!recentGames || recentGames.length === 0) {
-      return null;
-    }
-
-    const prioritized = recentGames.find((game) => {
-      const status = (game.status || '').toLowerCase();
-      return status.includes('progress');
-    }) || recentGames[0];
-
-    if (!prioritized) {
-      return null;
-    }
-
-    const rawMax = prioritized.max_rounds ?? prioritized.maxRounds ?? prioritized.total_rounds ?? 1;
-    const maxRounds = Math.max(rawMax || 1, 1);
-    const current = Math.min(prioritized.current_round ?? prioritized.currentRound ?? 0, maxRounds);
-    const percent = Math.round((current / maxRounds) * 100);
-
-    return {
-      id: prioritized.id,
-      name: prioritized.name || `Game ${prioritized.id}`,
-      currentRound: current,
-      maxRounds,
-      percent,
-    };
-  }, [recentGames]);
-
-  const focusGameId = useMemo(() => {
-    if (selectedGameId) {
-      return String(selectedGameId);
-    }
-    if (activeGameProgress?.id) {
-      return String(activeGameProgress.id);
-    }
-    if ((recentGames || []).length > 0 && recentGames[0]?.id) {
-      return String(recentGames[0].id);
-    }
-    return '';
-  }, [selectedGameId, activeGameProgress, recentGames]);
-
-  useEffect(() => {
-    setReasoningFocus('all');
-  }, [focusGameId]);
-
-  useEffect(() => {
-    let ignore = false;
-
-    if (!focusGameId) {
-      setReasoningData({
-        gameId: null,
-        gameName: '',
-        roles: [],
-        rows: [],
-        hasSupervisor: false,
-      });
-      setReasoningError(null);
-      setReasoningLoading(false);
-      return () => {
-        ignore = true;
-      };
-    }
-
-    const numericId = Number(focusGameId);
-    if (!Number.isFinite(numericId)) {
-      setReasoningData({
-        gameId: null,
-        gameName: '',
-        roles: [],
-        rows: [],
-        hasSupervisor: false,
-      });
-      setReasoningError(null);
-      setReasoningLoading(false);
-      return () => {
-        ignore = true;
-      };
-    }
-
-    const fallbackName =
-      (recentGames || []).find((g) => String(g.id) === String(focusGameId))?.name ||
-      `Game ${numericId}`;
-
-    const loadReasoning = async () => {
-      setReasoningLoading(true);
-      try {
-        const [players, rounds] = await Promise.all([
-          mixedGameApi.getPlayers(numericId),
-          mixedGameApi.getRounds(numericId),
-        ]);
-        if (ignore) return;
-        const parsed = buildReasoningTableData(
-          numericId,
-          fallbackName,
-          Array.isArray(players) ? players : [],
-          Array.isArray(rounds) ? rounds : []
-        );
-        setReasoningData(parsed);
-        setReasoningError(null);
-      } catch (err) {
-        if (ignore) return;
-        console.error('Failed to load reasoning data:', err);
-        setReasoningData({
-          gameId: numericId,
-          gameName: fallbackName,
-          roles: [],
-          rows: [],
-          hasSupervisor: false,
-        });
-        setReasoningError('Failed to load reasoning data for the selected game.');
-      } finally {
-        if (!ignore) {
-          setReasoningLoading(false);
-        }
-      }
-    };
-
-    loadReasoning();
-
-    return () => {
-      ignore = true;
-    };
-  }, [focusGameId, recentGames]);
-
-  const reasoningFocusOptions = useMemo(() => {
-    const options = [{ value: 'all', label: 'All players' }];
-    (reasoningData.roles || []).forEach((role) => {
-      if (role?.key) {
-        options.push({ value: role.key, label: role.label });
-      }
-    });
-    if (reasoningData.hasSupervisor) {
-      options.push({ value: 'supervisor', label: ROLE_DISPLAY_LABELS.supervisor });
-    }
-    return options;
-  }, [reasoningData.roles, reasoningData.hasSupervisor]);
-
-  const reasoningFocusLabel = useMemo(() => {
-    const match = reasoningFocusOptions.find((option) => option.value === reasoningFocus);
-    return match ? match.label : 'All players';
-  }, [reasoningFocusOptions, reasoningFocus]);
-
-  useEffect(() => {
-    if (!reasoningFocusOptions.some((option) => option.value === reasoningFocus)) {
-      setReasoningFocus('all');
-    }
-  }, [reasoningFocusOptions, reasoningFocus]);
-
-  const renderReasonCell = (entry) => {
-    if (!entry) {
-      return <div className="text-xs italic text-gray-400">No data recorded yet.</div>;
-    }
-
-    const metrics = [];
-    if (entry.order !== null && entry.order !== undefined) {
-      metrics.push(`Order ${entry.order}`);
-    }
-    if (entry.inventory !== null && entry.inventory !== undefined) {
-      metrics.push(`Inventory ${entry.inventory}`);
-    }
-    if (entry.backlog !== null && entry.backlog !== undefined) {
-      metrics.push(`Backlog ${entry.backlog}`);
-    }
-
-    return (
-      <div className="space-y-2">
-        {metrics.length > 0 && (
-          <div className="text-xs font-medium text-gray-500">{metrics.join(' • ')}</div>
-        )}
-        {entry.lines && entry.lines.length > 0 ? (
-          <div className="space-y-1 text-sm leading-snug text-gray-700">
-            {entry.lines.map((line, idx) => (
-              <p key={idx}>{line}</p>
-            ))}
-          </div>
-        ) : (
-          <p className="text-xs italic text-gray-400">No reasoning submitted.</p>
-        )}
-      </div>
-    );
+  const handleTabChange = (_event, newValue) => {
+    setActiveTab(newValue);
+    setSearchParams({ section: newValue });
   };
 
-  const renderSupervisorCell = (entries, targetRole = null) => {
-    if (!entries || Object.keys(entries).length === 0) {
-      return <div className="text-xs italic text-gray-400">No supervisor overrides.</div>;
+  const [games, setGames] = useState([]);
+  const [gamesLoading, setGamesLoading] = useState(true);
+  const [gamesError, setGamesError] = useState(null);
+
+  const refreshGames = useCallback(async () => {
+    setGamesLoading(true);
+    try {
+      const list = await mixedGameApi.getGames();
+      setGames(Array.isArray(list) ? list : []);
+      setGamesError(null);
+    } catch (error) {
+      const detail = error?.response?.data?.detail || error?.message || 'Unable to load games right now.';
+      setGames([]);
+      setGamesError(detail);
+    } finally {
+      setGamesLoading(false);
     }
-
-    const items = targetRole
-      ? Object.entries(entries).filter(([roleKey]) => roleKey === targetRole)
-      : Object.entries(entries);
-
-    if (items.length === 0) {
-      return <div className="text-xs italic text-gray-400">No supervisor overrides.</div>;
-    }
-
-    return (
-      <div className="space-y-3">
-        {items.map(([roleKey, value]) => (
-          <div key={roleKey} className="space-y-1">
-            {(!targetRole || items.length > 1) && (
-              <div className="text-xs font-semibold uppercase tracking-wide text-indigo-600">
-                {formatRoleLabel(roleKey)}
-              </div>
-            )}
-            {value.lines && value.lines.length > 0 ? (
-              <div className="space-y-1 text-sm leading-snug text-gray-700">
-                {value.lines.map((line, idx) => (
-                  <p key={`${roleKey}-${idx}`}>{line}</p>
-                ))}
-              </div>
-            ) : (
-              <p className="text-xs italic text-gray-400">No supervisor reasoning captured.</p>
-            )}
-          </div>
-        ))}
-      </div>
-    );
-  };
-
-  const reasoningGameName = reasoningData.gameName || (focusGameId ? `Game ${focusGameId}` : '');
-  const hasReasoningRows = (reasoningData.rows || []).length > 0;
-
-  const renderProgressSlider = (game) => {
-    const rawMax = game?.max_rounds ?? game?.maxRounds ?? game?.total_rounds ?? 1;
-    const maxRounds = Math.max(rawMax || 1, 1);
-    const current = Math.min(game?.current_round ?? game?.currentRound ?? 0, maxRounds);
-    const percent = Math.round((current / maxRounds) * 100);
-
-    return (
-      <div className="flex flex-col space-y-1">
-        <input
-          type="range"
-          min="0"
-          max={maxRounds}
-          value={current}
-          readOnly
-          className="accent-indigo-600 cursor-default"
-        />
-        <span className="text-xs text-gray-500">
-          {current} / {maxRounds} ({percent}%)
-        </span>
-      </div>
-    );
-  };
-
-  useEffect(() => {
-    if (!isGroupAdmin) navigate('/unauthorized');
-  }, [isGroupAdmin, navigate]);
-
-  useEffect(() => {
-    const fetchAll = async () => {
-      try {
-        setIsLoading(true);
-        const mockStats = {
-          totalUsers: 1245,
-          activeUsers: 342,
-          totalGames: 876,
-          activeGames: 23,
-          avgGameDuration: 45,
-          userGrowth: 12.5,
-          gameGrowth: 8.2,
-          userActivity: { labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'], data: [65, 59, 80, 81, 56, 55, 40] },
-          gameStats: { completed: 65, inProgress: 23, abandoned: 12 },
-          userDistribution: { new: 45, returning: 30, inactive: 25 },
-        };
-        const mockRecentUsers = [
-          { id: 1, username: 'johndoe', email: 'john@example.com', joined: '2023-05-15T10:30:00Z', status: 'active' },
-          { id: 2, username: 'alice_smith', email: 'alice@example.com', joined: '2023-05-14T15:45:00Z', status: 'active' },
-          { id: 3, username: 'bob_johnson', email: 'bob@example.com', joined: '2023-05-13T09:20:00Z', status: 'inactive' },
-        ];
-        setStats(mockStats);
-        setRecentUsers(mockRecentUsers);
-
-        try {
-          const games = await mixedGameApi.getGames();
-          setRecentGames(games || []);
-          const map = {};
-          (games || []).forEach((g) => {
-            map[g.id] = { node_policies: g.node_policies || {}, system_config: g.system_config || {} };
-          });
-          setGameConfigs(map);
-        } catch {
-          setRecentGames([]);
-        }
-        setError(null);
-      } catch (err) {
-        setError('Failed to load admin dashboard. Please try again later.');
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    fetchAll();
   }, []);
 
   useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    if (params.get('openSystemRanges') === '1') {
-      (async () => {
-        try {
-          const cfg = await mixedGameApi.getSystemConfig();
-          setRangeEdits(cfg || {});
-        } catch {
-          setRangeEdits({});
-        } finally {
-          setShowRangesModal(true);
-        }
-      })();
-    }
-  }, [location.search]);
+    refreshGames();
+  }, [refreshGames]);
 
-  const userActivityData = {
-    labels: stats?.userActivity?.labels || [],
-    datasets: [
-      {
-        label: 'Active Users',
-        data: stats?.userActivity?.data || [],
-        borderColor: 'rgb(99, 102, 241)',
-        backgroundColor: 'rgba(99, 102, 241, 0.1)',
-        tension: 0.3,
-        fill: true,
-      },
-    ],
-  };
+  const groupId = useMemo(() => {
+    const rawGroup = user?.group_id;
+    if (rawGroup == null) return null;
+    const parsed = Number(rawGroup);
+    return Number.isFinite(parsed) ? parsed : null;
+  }, [user]);
 
-  const gameStatusData = {
-    labels: ['Completed', 'In Progress', 'Abandoned'],
-    datasets: [
-      {
-        data: [stats?.gameStats?.completed || 0, stats?.gameStats?.inProgress || 0, stats?.gameStats?.abandoned || 0],
-        backgroundColor: ['rgba(16, 185, 129, 0.8)', 'rgba(59, 130, 246, 0.8)', 'rgba(239, 68, 68, 0.8)'],
-        borderColor: ['rgba(16, 185, 129, 1)', 'rgba(59, 130, 246, 1)', 'rgba(239, 68, 68, 1)'],
-        borderWidth: 1,
-      },
-    ],
-  };
+  const currentUserId = user?.id ?? null;
 
-  const userDistributionData = {
-    labels: ['New Users', 'Returning Users', 'Inactive Users'],
-    datasets: [
-      {
-        data: [stats?.userDistribution?.new || 0, stats?.userDistribution?.returning || 0, stats?.userDistribution?.inactive || 0],
-        backgroundColor: ['rgba(99, 102, 241, 0.8)', 'rgba(139, 92, 246, 0.8)', 'rgba(156, 163, 175, 0.8)'],
-        borderColor: ['rgba(99, 102, 241, 1)', 'rgba(139, 92, 246, 1)', 'rgba(156, 163, 175, 1)'],
-        borderWidth: 1,
-      },
-    ],
-  };
-
-  const chartOptions = { responsive: true, plugins: { legend: { position: 'top' } }, scales: { y: { beginAtZero: true, ticks: { precision: 0 } } } };
-
-  const formatDateTime = (iso) => {
-    if (!iso) return '-';
-    try {
-      const d = new Date(iso);
-      return `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`;
-    } catch {
-      return '-';
-    }
-  };
-  const humanDuration = (startIso, endIso) => {
-    try {
-      const start = startIso ? new Date(startIso).getTime() : null;
-      const end = endIso ? new Date(endIso).getTime() : Date.now();
-      if (!start) return '-';
-      const mins = Math.floor(Math.max(0, end - start) / 60000);
-      const hrs = Math.floor(mins / 60);
-      const rem = mins % 60;
-      return hrs > 0 ? `${hrs}h ${rem}m` : `${mins}m`;
-    } catch {
-      return '-';
-    }
-  };
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const games = await mixedGameApi.getGames();
-        const mine = (games || []).filter(g => g.created_by === user?.id);
-        setMyGames(mine);
-      } catch (e) {
-        // ignore
-      }
-    })();
-  }, [user?.id]);
-
-  if (isLoading) {
+  if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 p-8">
-        <div className="animate-pulse space-y-6">
-          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
-          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
-            {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="card-surface pad-6 rounded-lg h-32"></div>
-            ))}
-          </div>
-        </div>
-      </div>
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="60vh">
+        <CircularProgress />
+      </Box>
     );
   }
 
-  if (error) {
-    return (
-      <div className="min-h-screen bg-gray-50 p-8">
-        <div className="bg-red-50 border-l-4 border-red-400 p-4">{error}</div>
-      </div>
-    );
+  if (!user) {
+    return <Navigate to="/unauthorized" replace />;
+  }
+
+  if (isSystemAdmin && !isGroupAdmin) {
+    return <Navigate to="/admin/groups" replace />;
+  }
+
+  if (!isGroupAdmin) {
+    return <Navigate to="/unauthorized" replace />;
   }
 
   return (
-    <>
-      <div className="min-h-screen bg-gray-50">
-        {/* Header */}
-        <div className="card-surface">
-          <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between items-center">
-              <h1 className="text-2xl font-bold text-gray-900">Admin Dashboard</h1>
-              <div className="flex space-x-3">
-                {/* Game selector (only games created by this admin) */}
-                {myGames.length > 0 && (
-                  <select
-                    className="block pl-3 pr-10 py-2 text-sm border-gray-300 rounded-md"
-                    value={selectedGameId}
-                    onChange={(e) => navigate(`/admin?gameId=${e.target.value}`)}
-                    title="Select a game to view context-aware dashboards"
-                  >
-                    <option value="">Select Game…</option>
-                    {myGames.map((g) => (
-                      <option key={g.id} value={g.id}>{g.name}</option>
-                    ))}
-                  </select>
-                )}
-                <button type="button" onClick={() => navigate('/users')} className="inline-flex items-center px-4 py-2 text-sm rounded-md text-white bg-indigo-600">
-                  <UsersIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
-                  Users
-                </button>
-                <button type="button" onClick={() => setShowRangesModal(true)} className="inline-flex items-center px-4 py-2 text-sm rounded-md text-white bg-blue-600">
-                  <CogIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
-                  Edit Ranges
-                </button>
-                <button type="button" onClick={() => navigate('/admin/model-setup')} className="inline-flex items-center px-4 py-2 text-sm rounded-md text-white bg-indigo-600">
-                  <CogIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
-                  Model Setup
-                </button>
-                <button type="button" onClick={() => navigate('/admin/training')} className="inline-flex items-center px-4 py-2 text-sm rounded-md text-white bg-green-600">
-                  Training
-                </button>
-              </div>
-            </div>
-            {/* Tabs */}
-            <div className="mt-6 border-b border-gray-200">
-              <nav className="-mb-px flex space-x-8">
-                {[
-                  { name: 'Overview', id: 'overview', icon: ChartBarIcon },
-                  { name: 'Users', id: 'users', icon: UsersIcon },
-                  { name: 'Games', id: 'games', icon: UserGroupIcon },
-                  { name: 'Security', id: 'security', icon: ShieldCheckIcon },
-                  { name: 'Reports', id: 'reports', icon: DocumentTextIcon },
-                ].map((tab) => (
-                  <button
-                    key={tab.id}
-                    onClick={() => setActiveTab(tab.id)}
-                    className={`${activeTab === tab.id ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm flex items-center`}
-                  >
-                    <tab.icon className="mr-2 h-5 w-5" />
-                    {tab.name}
-                  </button>
-                ))}
-              </nav>
-            </div>
-          </div>
-        </div>
+    <Box sx={{ maxWidth: 1200, mx: 'auto', py: 4, px: { xs: 2, md: 3 } }}>
+      <Paper elevation={0} sx={{ mb: 4, p: { xs: 2, md: 3 } }}>
+        <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+          Group Administrator Workspace
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Configure your supply chain templates, manage player access, and supervise active games from a single workspace.
+        </Typography>
+        <Tabs
+          value={activeTab}
+          onChange={handleTabChange}
+          variant="scrollable"
+          allowScrollButtonsMobile
+          sx={{ mt: 3 }}
+        >
+          {tabItems.map((tab) => (
+            <Tab
+              key={tab.value}
+              value={tab.value}
+              iconPosition="start"
+              icon={tab.icon}
+              label={tab.label}
+              sx={{ textTransform: 'none', fontWeight: 600 }}
+            />
+          ))}
+        </Tabs>
+      </Paper>
 
-        <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-          {/* Overview */}
-          {activeTab === 'overview' && (
-            <div className="space-y-6">
-              <div className="card-surface pad-6 rounded-lg">
-                <div className="flex items-center justify-between mb-4">
-                  <div>
-                    <h3 className="text-lg font-medium text-gray-900">Game Progress</h3>
-                    <p className="text-sm text-gray-500">
-                      {activeGameProgress
-                        ? `${activeGameProgress.name} · Week ${activeGameProgress.currentRound} of ${activeGameProgress.maxRounds}`
-                        : 'No active games at the moment'}
-                    </p>
-                  </div>
-                  <span className="text-sm font-semibold text-indigo-600">
-                    {activeGameProgress ? `${activeGameProgress.percent}%` : ''}
-                  </span>
-                </div>
-                <input
-                  type="range"
-                  min="0"
-                  max={activeGameProgress?.maxRounds || 1}
-                  value={activeGameProgress?.currentRound || 0}
-                  readOnly
-                  className="w-full accent-indigo-600 cursor-default"
-                />
-                <div className="flex justify-between text-xs text-gray-500 mt-2">
-                  <span>0</span>
-                  <span>
-                    {activeGameProgress
-                      ? `${activeGameProgress.currentRound} / ${activeGameProgress.maxRounds} rounds`
-                      : 'Awaiting game data'}
-                  </span>
-                  <span>{activeGameProgress?.maxRounds || 1}</span>
-                </div>
-              </div>
+      <Box>
+        {activeTab === 'sc' && (
+          <GroupSupplyChainConfigList />
+        )}
 
-              <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
-                <StatCard title="Total Users" value={stats?.totalUsers?.toLocaleString() || '0'} icon={UsersIcon} change={stats?.userGrowth} changeType={stats?.userGrowth >= 0 ? 'increase' : 'decrease'} />
-                <StatCard title="Active Users" value={stats?.activeUsers?.toLocaleString() || '0'} icon={UserCircleIcon} />
-                <StatCard title="Total Games" value={stats?.totalGames?.toLocaleString() || '0'} icon={UserGroupIcon} change={stats?.gameGrowth} changeType={stats?.gameGrowth >= 0 ? 'increase' : 'decrease'} />
-                <StatCard title="Active Games" value={stats?.activeGames?.toLocaleString() || '0'} icon={ClockIcon} />
-              </div>
+        {activeTab === 'game' && (
+          <GroupGameConfigPanel
+            games={games}
+            loading={gamesLoading}
+            error={gamesError}
+            onRefresh={refreshGames}
+            groupId={groupId}
+            currentUserId={currentUserId}
+          />
+        )}
 
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <div className="card-surface pad-6 rounded-lg">
-                  <h3 className="text-lg font-medium text-gray-900 mb-4">User Activity (Last 7 Days)</h3>
-                  <div className="h-80">
-                    <Line data={userActivityData} options={chartOptions} />
-                  </div>
-                </div>
-                <div className="grid grid-rows-2 gap-6">
-                  <div className="card-surface pad-6 rounded-lg">
-                    <h3 className="text-lg font-medium text-gray-900 mb-4">Game Status</h3>
-                    <div className="h-64">
-                      <Pie data={gameStatusData} options={chartOptions} />
-                    </div>
-                  </div>
-                  <div className="card-surface pad-6 rounded-lg">
-                    <h3 className="text-lg font-medium text-gray-900 mb-4">User Distribution</h3>
-                    <div className="h-64">
-                      <Pie data={userDistributionData} options={chartOptions} />
-                    </div>
-                  </div>
-                </div>
-              </div>
+        {activeTab === 'users' && <GroupPlayerManagement />}
 
-              <div className="card-surface pad-6 rounded-lg">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
-                  <div>
-                    <h3 className="text-lg font-medium text-gray-900">Order Reasoning by Week</h3>
-                    <p className="text-sm text-gray-500">
-                      {focusGameId
-                        ? `${reasoningGameName || `Game ${focusGameId}`} · ${reasoningFocusLabel}`
-                        : 'Select a game to review decision rationale.'}
-                    </p>
-                  </div>
-                  {reasoningFocusOptions.length > 1 && (
-                    <div className="flex items-center space-x-2">
-                      <label
-                        htmlFor="reasoning-focus"
-                        className="text-xs font-medium uppercase tracking-wide text-gray-500"
-                      >
-                        Focus
-                      </label>
-                      <select
-                        id="reasoning-focus"
-                        value={reasoningFocus}
-                        onChange={(event) => setReasoningFocus(event.target.value)}
-                        className="border-gray-300 text-sm rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                      >
-                        {reasoningFocusOptions.map((option) => (
-                          <option key={option.value} value={option.value}>
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  )}
-                </div>
-                {reasoningLoading ? (
-                  <div className="space-y-3">
-                    <div className="h-4 w-2/3 rounded bg-gray-100 animate-pulse" />
-                    <div className="h-4 w-full rounded bg-gray-100 animate-pulse" />
-                    <div className="h-4 w-5/6 rounded bg-gray-100 animate-pulse" />
-                  </div>
-                ) : reasoningError ? (
-                  <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-                    {reasoningError}
-                  </div>
-                ) : !focusGameId ? (
-                  <p className="text-sm text-gray-500">Select a game to view player reasoning.</p>
-                ) : hasReasoningRows ? (
-                  <div className="overflow-x-auto">
-                    {reasoningFocus === 'all' ? (
-                      <table className="min-w-full divide-y divide-gray-200">
-                        <thead className="bg-gray-50">
-                          <tr>
-                            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
-                              Week
-                            </th>
-                            {reasoningData.roles.map((role) => (
-                              <th
-                                key={role.key}
-                                className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500"
-                              >
-                                {role.label}
-                              </th>
-                            ))}
-                            {reasoningData.hasSupervisor && (
-                              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
-                                Supervisor
-                              </th>
-                            )}
-                          </tr>
-                        </thead>
-                        <tbody className="bg-white divide-y divide-gray-200">
-                          {reasoningData.rows.map((row, idx) => (
-                            <tr key={row.week ?? `row-${idx}`}>
-                              <td className="px-4 py-3 align-top text-sm font-medium text-gray-700">
-                                Week {row.week ?? '—'}
-                              </td>
-                              {reasoningData.roles.map((role) => (
-                                <td key={`${role.key}-${idx}`} className="px-4 py-3 align-top">
-                                  {renderReasonCell(row.roles[role.key])}
-                                </td>
-                              ))}
-                              {reasoningData.hasSupervisor && (
-                                <td className="px-4 py-3 align-top">
-                                  {renderSupervisorCell(row.supervisor)}
-                                </td>
-                              )}
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    ) : (
-                      <table className="min-w-full divide-y divide-gray-200">
-                        <thead className="bg-gray-50">
-                          <tr>
-                            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
-                              Week
-                            </th>
-                            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
-                              {reasoningFocusLabel}
-                            </th>
-                          </tr>
-                        </thead>
-                        <tbody className="bg-white divide-y divide-gray-200">
-                          {reasoningData.rows.map((row, idx) => (
-                            <tr key={row.week ?? `focus-${idx}`}>
-                              <td className="px-4 py-3 align-top text-sm font-medium text-gray-700">
-                                Week {row.week ?? '—'}
-                              </td>
-                              <td className="px-4 py-3 align-top">
-                                {reasoningFocus === 'supervisor'
-                                  ? renderSupervisorCell(row.supervisor)
-                                  : renderReasonCell(row.roles[reasoningFocus])}
-                              </td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    )}
-                  </div>
-                ) : (
-                  <p className="text-sm text-gray-500">
-                    No reasoning has been recorded yet for this game.
-                  </p>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Users */}
-          {activeTab === 'users' && (
-            <div className="card-surface overflow-hidden sm:rounded-lg">
-              <div className="pad-6 border-b border-gray-200">
-                <h3 className="text-lg leading-6 font-medium text-gray-900">User Management</h3>
-              </div>
-              <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Joined</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                    </tr>
-                  </thead>
-                  <tbody className="bg-white divide-y divide-gray-200">
-                    {recentUsers.map((user) => (
-                      <tr key={user.id}>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="flex items-center">
-                            <div className="flex-shrink-0 h-10 w-10 rounded-full bg-indigo-100 flex items-center justify-center">
-                              <UserCircleIcon className="h-8 w-8 text-indigo-500" />
-                            </div>
-                            <div className="ml-4">
-                              <div className="text-sm font-medium text-gray-900">{user.username}</div>
-                              <div className="text-sm text-gray-500">ID: {user.id}</div>
-                            </div>
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="text-sm text-gray-900">{user.email}</div>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="text-sm text-gray-900">{new Date(user.joined).toLocaleDateString()}</div>
-                          <div className="text-sm text-gray-500">{new Date(user.joined).toLocaleTimeString()}</div>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <UserStatusBadge status={user.status} />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          )}
-
-          {/* Games */}
-          {activeTab === 'games' && (
-            <div className="table-surface overflow-hidden sm:rounded-lg">
-              <div className="pad-6 border-b border-gray-200">
-                <h3 className="text-lg leading-6 font-medium text-gray-900">Game Management</h3>
-                <p className="mt-1 max-w-2xl text-sm text-gray-500">View and manage active and completed games</p>
-              </div>
-              <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Game</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Players</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Progress</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Started</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
-                    </tr>
-                  </thead>
-                  <tbody className="bg-white divide-y divide-gray-200">
-                    {recentGames.map((game) => (
-                      <tr key={game.id}>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="text-sm font-medium text-gray-900 truncate max-w-xs">
-                            {game.name} <span className="text-gray-500">(ID: {game.id})</span>
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <GameStatusBadge status={game.status} />
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="text-sm text-gray-900">{Array.isArray(game.players) ? game.players.length : game.players ?? 0}</div>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          {renderProgressSlider(game)}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="text-sm text-gray-900 truncate max-w-[12rem]">{formatDateTime(game.started_at || game.created_at)}</div>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{humanDuration(game.started_at || game.created_at, game.completed_at)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          )}
-
-          {/* Security */}
-          {activeTab === 'security' && (
-            <div className="card-surface pad-6 rounded-lg">
-              <h3 className="text-lg font-medium text-gray-900 mb-4">Security Settings</h3>
-              <div className="space-y-4">
-                <label className="flex items-center space-x-3 text-sm"><input type="checkbox" defaultChecked className="h-4 w-4" /> <span>Require email verification</span></label>
-                <label className="flex items-center space-x-3 text-sm"><input type="checkbox" className="h-4 w-4" /> <span>Enable two-factor authentication</span></label>
-                <label className="flex items-center space-x-3 text-sm"><input type="checkbox" defaultChecked className="h-4 w-4" /> <span>Allow password reset</span></label>
-              </div>
-            </div>
-          )}
-
-          {/* Reports */}
-          {activeTab === 'reports' && (
-            <div className="bg-white shadow overflow-hidden sm:rounded-lg">
-              <div className="px-4 py-5 sm:px-6 border-b border-gray-200">
-                <div className="flex justify-between items-center">
-                  <div>
-                    <h3 className="text-lg leading-6 font-medium text-gray-900">Reports</h3>
-                    <p className="mt-1 max-w-2xl text-sm text-gray-500">Generate and download system reports</p>
-                  </div>
-                  <div className="flex space-x-3">
-                    <select id="report-type" name="report-type" className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 sm:text-sm rounded-md" defaultValue="user-activity">
-                      <option value="user-activity">User Activity</option>
-                      <option value="game-stats">Game Statistics</option>
-                      <option value="system-usage">System Usage</option>
-                      <option value="financial">Financial Reports</option>
-                    </select>
-                    <button type="button" className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600">Generate Report</button>
-                  </div>
-                </div>
-              </div>
-              <div className="px-4 py-5 sm:p-6">
-                <div className="h-48 flex items-center justify-center border-2 border-dashed border-gray-300 rounded-lg">
-                  <div className="text-center text-sm text-gray-600">Select a report type and click Generate.</div>
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* Ranges Modal */}
-      <RangesModal
-        visible={showRangesModal}
-        rangeEdits={rangeEdits}
-        originalConfig={(gameConfigs[null] || {}).system_config || {}}
-        onClose={() => {
-          setShowRangesModal(false);
-          // Reset to current config (if editing from a game), otherwise keep existing
-        }}
-        onChange={(key, next) => setRangeEdits((prev) => ({ ...prev, [key]: next }))}
-        onSave={async () => {
-          try {
-            await mixedGameApi.saveSystemConfig(rangeEdits);
-            const games = await mixedGameApi.getGames();
-            const map = {};
-            (games || []).forEach((g) => {
-              map[g.id] = { node_policies: g.node_policies || {}, system_config: g.system_config || {} };
-            });
-            setGameConfigs(map);
-            setShowRangesModal(false);
-          } catch (error) {
-            console.error('Failed to save system config:', error);
-          }
-        }}
-      />
-    </>
+        {activeTab === 'supervision' && (
+          <GroupGameSupervisionPanel
+            games={games}
+            loading={gamesLoading}
+            error={gamesError}
+            onRefresh={refreshGames}
+            groupId={groupId}
+            currentUserId={currentUserId}
+          />
+        )}
+      </Box>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/admin/GroupGameConfigPanel.jsx
+++ b/frontend/src/pages/admin/GroupGameConfigPanel.jsx
@@ -1,0 +1,170 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  Stack,
+  Alert,
+} from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { format } from 'date-fns';
+
+const formatDate = (value) => {
+  if (!value) return '—';
+  try {
+    return format(new Date(value), 'MMM d, yyyy HH:mm');
+  } catch (error) {
+    return String(value);
+  }
+};
+
+const statusColor = (status = '') => {
+  const normalized = String(status).toLowerCase();
+  if (normalized === 'created') return 'default';
+  if (normalized === 'in_progress') return 'info';
+  if (normalized === 'completed') return 'success';
+  if (normalized === 'paused') return 'warning';
+  return 'default';
+};
+
+const GroupGameConfigPanel = ({
+  games = [],
+  loading = false,
+  error = null,
+  onRefresh,
+  groupId = null,
+  currentUserId = null,
+}) => {
+  const navigate = useNavigate();
+
+  const filteredGames = useMemo(() => {
+    if (!Array.isArray(games) || games.length === 0) {
+      return [];
+    }
+
+    return games.filter((game) => {
+      if (!game) return false;
+      const targetGroup = game.group_id ?? game?.config?.group_id ?? null;
+      if (groupId != null) {
+        if (targetGroup != null) {
+          return Number(targetGroup) === Number(groupId);
+        }
+        if (game.created_by != null) {
+          return Number(game.created_by) === Number(currentUserId);
+        }
+      }
+      return true;
+    });
+  }, [games, groupId, currentUserId]);
+
+  const handleCreateGame = () => {
+    navigate('/games/new');
+  };
+
+  const handleViewGame = (gameId) => {
+    navigate(`/games/${gameId}`);
+  };
+
+  return (
+    <Paper elevation={0} sx={{ p: 3 }}>
+      <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ xs: 'stretch', md: 'center' }} spacing={2} mb={3}>
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 700 }}>
+            Game Configuration
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Review recent mixed game setups and create new sessions for your group.
+          </Typography>
+        </Box>
+        <Stack direction="row" spacing={1}>
+          {onRefresh && (
+            <Button variant="outlined" onClick={onRefresh} disabled={loading}>
+              Refresh
+            </Button>
+          )}
+          <Button variant="contained" color="primary" onClick={handleCreateGame}>
+            New Mixed Game
+          </Button>
+        </Stack>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight={240}>
+          <CircularProgress />
+        </Box>
+      ) : filteredGames.length === 0 ? (
+        <Box textAlign="center" py={6}>
+          <Typography variant="body1" color="text.secondary" gutterBottom>
+            No games found for your group yet.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Configure a new mixed game to get your players started.
+          </Typography>
+        </Box>
+      ) : (
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Current Round</TableCell>
+                <TableCell>Max Rounds</TableCell>
+                <TableCell>Last Updated</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filteredGames.map((game) => (
+                <TableRow hover key={game.id}>
+                  <TableCell>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                      {game.name}
+                    </Typography>
+                    {game.description && (
+                      <Typography variant="body2" color="text.secondary" noWrap>
+                        {game.description}
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      color={statusColor(game.status)}
+                      label={(game.status || '').replace(/_/g, ' ') || 'Unknown'}
+                    />
+                  </TableCell>
+                  <TableCell>{game.current_round ?? 0}</TableCell>
+                  <TableCell>{game.max_rounds ?? '—'}</TableCell>
+                  <TableCell>{formatDate(game.updated_at)}</TableCell>
+                  <TableCell align="right">
+                    <Button size="small" variant="outlined" onClick={() => handleViewGame(game.id)}>
+                      View
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Paper>
+  );
+};
+
+export default GroupGameConfigPanel;

--- a/frontend/src/pages/admin/GroupGameSupervisionPanel.jsx
+++ b/frontend/src/pages/admin/GroupGameSupervisionPanel.jsx
@@ -1,0 +1,289 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  PlayArrow as StartIcon,
+  Stop as StopIcon,
+  Flag as FinishIcon,
+  SkipNext as NextRoundIcon,
+  Visibility as ViewIcon,
+} from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
+import { useNavigate } from 'react-router-dom';
+import { format } from 'date-fns';
+import { mixedGameApi } from '../../services/api';
+
+const formatDate = (value) => {
+  if (!value) return '—';
+  try {
+    return format(new Date(value), 'MMM d, yyyy HH:mm');
+  } catch (error) {
+    return String(value);
+  }
+};
+
+const statusLabel = (status = '') => (status || 'unknown').replace(/_/g, ' ');
+
+const statusColor = (status = '') => {
+  const normalized = String(status).toLowerCase();
+  if (normalized === 'created') return 'default';
+  if (normalized === 'in_progress') return 'info';
+  if (normalized === 'completed') return 'success';
+  if (normalized === 'paused') return 'warning';
+  if (normalized === 'failed' || normalized === 'error') return 'error';
+  return 'default';
+};
+
+const GroupGameSupervisionPanel = ({
+  games = [],
+  loading = false,
+  error = null,
+  onRefresh,
+  groupId = null,
+  currentUserId = null,
+}) => {
+  const navigate = useNavigate();
+  const { enqueueSnackbar } = useSnackbar();
+  const [actionState, setActionState] = useState({});
+
+  const supervisedGames = useMemo(() => {
+    if (!Array.isArray(games)) {
+      return [];
+    }
+
+    return games.filter((game) => {
+      if (!game) return false;
+      const targetGroup = game.group_id ?? game?.config?.group_id ?? null;
+      if (groupId != null) {
+        if (targetGroup != null) {
+          return Number(targetGroup) === Number(groupId);
+        }
+        if (game.created_by != null) {
+          return Number(game.created_by) === Number(currentUserId);
+        }
+      }
+      return true;
+    });
+  }, [games, groupId, currentUserId]);
+
+  const setGameActionState = (gameId, state) => {
+    setActionState((prev) => ({ ...prev, [gameId]: state }));
+  };
+
+  const runAction = async (gameId, action, apiCall, successMessage) => {
+    setGameActionState(gameId, action);
+    try {
+      await apiCall(gameId);
+      enqueueSnackbar(successMessage, { variant: 'success' });
+      if (onRefresh) {
+        await onRefresh();
+      }
+    } catch (err) {
+      const detail = err?.response?.data?.detail || err?.message || 'Action failed';
+      enqueueSnackbar(detail, { variant: 'error' });
+    } finally {
+      setGameActionState(gameId, null);
+    }
+  };
+
+  const handleStart = (gameId) =>
+    runAction(gameId, 'start', mixedGameApi.startGame, 'Game started');
+  const handleStop = (gameId) => runAction(gameId, 'stop', mixedGameApi.stopGame, 'Game stopped');
+  const handleNextRound = (gameId) =>
+    runAction(gameId, 'next_round', mixedGameApi.nextRound, 'Advanced to next round');
+  const handleFinish = (gameId) =>
+    runAction(gameId, 'finish', mixedGameApi.finishGame, 'Game marked as finished');
+
+  const handleView = (gameId) => {
+    navigate(`/games/${gameId}`);
+  };
+
+  const renderActions = (game) => {
+    const status = String(game.status || '').toLowerCase();
+    const busy = Boolean(actionState[game.id]);
+
+    if (status === 'completed') {
+      return (
+        <Tooltip title="View game">
+          <span>
+            <IconButton color="primary" onClick={() => handleView(game.id)}>
+              <ViewIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      );
+    }
+
+    if (status === 'created' || status === 'paused') {
+      return (
+        <Stack direction="row" spacing={1}>
+          <Tooltip title="View game">
+            <span>
+              <IconButton color="primary" onClick={() => handleView(game.id)}>
+                <ViewIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Button
+            size="small"
+            variant="contained"
+            color="success"
+            startIcon={<StartIcon fontSize="small" />}
+            onClick={() => handleStart(game.id)}
+            disabled={busy}
+          >
+            {busy ? 'Starting…' : 'Start'}
+          </Button>
+        </Stack>
+      );
+    }
+
+    if (status === 'in_progress') {
+      return (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Tooltip title="View game">
+            <span>
+              <IconButton color="primary" onClick={() => handleView(game.id)}>
+                <ViewIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<NextRoundIcon fontSize="small" />}
+            onClick={() => handleNextRound(game.id)}
+            disabled={busy}
+          >
+            {busy && actionState[game.id] === 'next_round' ? 'Advancing…' : 'Next Round'}
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            color="warning"
+            startIcon={<FinishIcon fontSize="small" />}
+            onClick={() => handleFinish(game.id)}
+            disabled={busy}
+          >
+            {busy && actionState[game.id] === 'finish' ? 'Finishing…' : 'Finish'}
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            color="error"
+            startIcon={<StopIcon fontSize="small" />}
+            onClick={() => handleStop(game.id)}
+            disabled={busy}
+          >
+            {busy && actionState[game.id] === 'stop' ? 'Stopping…' : 'Stop'}
+          </Button>
+        </Stack>
+      );
+    }
+
+    return (
+      <Tooltip title="View game">
+        <span>
+          <IconButton color="primary" onClick={() => handleView(game.id)}>
+            <ViewIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+    );
+  };
+
+  return (
+    <Paper elevation={0} sx={{ p: 3 }}>
+      <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ xs: 'stretch', md: 'center' }} spacing={2} mb={3}>
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 700 }}>
+            Game Supervision
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Monitor live sessions and orchestrate progress across your group's games.
+          </Typography>
+        </Box>
+        {onRefresh && (
+          <Button variant="outlined" onClick={onRefresh} disabled={loading}>
+            Refresh
+          </Button>
+        )}
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight={240}>
+          <CircularProgress />
+        </Box>
+      ) : supervisedGames.length === 0 ? (
+        <Box textAlign="center" py={6}>
+          <Typography variant="body1" color="text.secondary" gutterBottom>
+            There are no games to supervise right now.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Create a new mixed game or wait for a session to begin.
+          </Typography>
+        </Box>
+      ) : (
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Round</TableCell>
+                <TableCell>Last Updated</TableCell>
+                <TableCell align="right">Controls</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {supervisedGames.map((game) => (
+                <TableRow hover key={game.id}>
+                  <TableCell>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                      {game.name}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {game.description || 'No description provided'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Chip size="small" color={statusColor(game.status)} label={statusLabel(game.status)} />
+                  </TableCell>
+                  <TableCell>
+                    {game.current_round ?? 0} / {game.max_rounds ?? '—'}
+                  </TableCell>
+                  <TableCell>{formatDate(game.updated_at)}</TableCell>
+                  <TableCell align="right">{renderActions(game)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Paper>
+  );
+};
+
+export default GroupGameSupervisionPanel;

--- a/frontend/src/pages/admin/GroupManagement.jsx
+++ b/frontend/src/pages/admin/GroupManagement.jsx
@@ -79,7 +79,7 @@ const GroupManagement = () => {
     async (nextSelectedId = null) => {
       setIsLoading(true);
       try {
-        const response = await api.get('/api/v1/groups');
+        const response = await api.get('/groups');
         const data = Array.isArray(response.data) ? response.data : [];
         setGroups(data);
 
@@ -127,7 +127,7 @@ const GroupManagement = () => {
     };
 
     try {
-      const { data } = await api.post('/api/v1/groups', payload);
+      const { data } = await api.post('/groups', payload);
       toast.success('Group and default setup created successfully');
       closeModal();
       await fetchGroups(data?.id);
@@ -206,7 +206,7 @@ const GroupManagement = () => {
 
     try {
       if (editingGroupId) {
-        await api.put(`/api/v1/groups/${editingGroupId}`, {
+        await api.put(`/groups/${editingGroupId}`, {
           name: trimmedName,
           description: form.description,
           logo: form.logo,
@@ -215,7 +215,7 @@ const GroupManagement = () => {
         closeModal();
         await fetchGroups(editingGroupId);
       } else {
-        const { data } = await api.post('/api/v1/groups', {
+        const { data } = await api.post('/groups', {
           ...form,
           name: trimmedName,
         });
@@ -254,7 +254,7 @@ const GroupManagement = () => {
     const groupId = deleteTarget.id;
 
     try {
-      await api.delete(`/api/v1/groups/${groupId}`);
+      await api.delete(`/groups/${groupId}`);
       toast.success('Group deleted');
       setDeleteTarget(null);
       setSelectedGroupId((prev) => (prev === groupId ? null : prev));

--- a/frontend/src/pages/admin/GroupSupplyChainConfigList.jsx
+++ b/frontend/src/pages/admin/GroupSupplyChainConfigList.jsx
@@ -38,6 +38,7 @@ const GroupSupplyChainConfigList = () => {
       title="My Group's Supply Chain Configurations"
       basePath="/admin/group/supply-chain-configs"
       restrictToGroupId={restrictToGroupId}
+      enableTraining
     />
   );
 };

--- a/frontend/src/pages/admin/SystemAdminUserManagement.jsx
+++ b/frontend/src/pages/admin/SystemAdminUserManagement.jsx
@@ -79,7 +79,7 @@ function SystemAdminUserManagement() {
 
   const loadGroups = useCallback(async () => {
     try {
-      const response = await api.get('/api/v1/groups');
+      const response = await api.get('/groups');
       const data = Array.isArray(response.data) ? response.data : [];
       setGroups(data);
       return data;
@@ -92,7 +92,7 @@ function SystemAdminUserManagement() {
 
   const loadAdmins = useCallback(async () => {
     try {
-      const response = await api.get('/api/v1/users', { params: { user_type: 'group_admin', limit: 250 } });
+      const response = await api.get('/users', { params: { user_type: 'group_admin', limit: 250 } });
       const data = Array.isArray(response.data) ? response.data : [];
       const filtered = data.filter((item) => getUserType(item) === 'group_admin');
       setAdmins(filtered);
@@ -194,10 +194,10 @@ function SystemAdminUserManagement() {
     setSaving(true);
     try {
       if (editingUser) {
-        await api.put(`/api/v1/users/${editingUser.id}`, payload);
+        await api.put(`/users/${editingUser.id}`, payload);
         toast.success('Group administrator updated successfully');
       } else {
-        await api.post('/api/v1/users', payload);
+        await api.post('/users', payload);
         toast.success('Group administrator created successfully');
       }
 
@@ -217,7 +217,7 @@ function SystemAdminUserManagement() {
     if (!window.confirm(confirmMessage)) return;
 
     try {
-      await api.delete(`/api/v1/users/${admin.id}`);
+      await api.delete(`/users/${admin.id}`);
       toast.success('Group administrator deleted');
       await loadAdmins();
     } catch (error) {

--- a/frontend/src/pages/admin/UserManagement.js
+++ b/frontend/src/pages/admin/UserManagement.js
@@ -80,7 +80,7 @@ function GroupPlayerManagement() {
 
   const loadGroups = useCallback(async () => {
     try {
-      const response = await api.get('/api/v1/groups');
+      const response = await api.get('/groups');
       const data = Array.isArray(response.data) ? response.data : [];
       setGroups(data);
       return data;
@@ -98,7 +98,7 @@ function GroupPlayerManagement() {
     }
 
     try {
-      const response = await api.get('/api/v1/users', {
+      const response = await api.get('/users', {
         params: { limit: 250, user_type: 'player' },
       });
       const data = Array.isArray(response.data) ? response.data : [];
@@ -203,10 +203,10 @@ function GroupPlayerManagement() {
     setSaving(true);
     try {
       if (editingUser) {
-        await api.put(`/api/v1/users/${editingUser.id}`, payload);
+        await api.put(`/users/${editingUser.id}`, payload);
         toast.success('Player updated successfully');
       } else {
-        await api.post('/api/v1/users', payload);
+        await api.post('/users', payload);
         toast.success('Player created successfully');
       }
 
@@ -226,7 +226,7 @@ function GroupPlayerManagement() {
     if (!window.confirm(confirmMessage)) return;
 
     try {
-      await api.delete(`/api/v1/users/${player.id}`);
+      await api.delete(`/users/${player.id}`);
       toast.success('Player deleted');
       await loadPlayers();
     } catch (error) {

--- a/frontend/src/services/dashboardService.js
+++ b/frontend/src/services/dashboardService.js
@@ -1,4 +1,4 @@
-import api from './api';
+import { api } from './api';
 
 /**
  * Get human dashboard data

--- a/frontend/src/services/gameService.js
+++ b/frontend/src/services/gameService.js
@@ -1,6 +1,6 @@
-import api from './api';
+import { api } from './api';
 
-const GAME_BASE_URL = '/api/v1/games';
+const GAME_BASE_URL = '/games';
 
 // Game CRUD operations
 export const createGame = async (gameData) => {

--- a/frontend/src/services/modelService.js
+++ b/frontend/src/services/modelService.js
@@ -1,4 +1,4 @@
-import api from './api';
+import { api } from './api';
 
 /**
  * Get the status of the Daybreak agent model

--- a/frontend/src/services/supplyChainConfigService.js
+++ b/frontend/src/services/supplyChainConfigService.js
@@ -1,6 +1,6 @@
-import api from './api';
+import { api } from './api';
 
-const SUPPLY_CHAIN_CONFIG_BASE_URL = '/api/v1/supply-chain-config';
+const SUPPLY_CHAIN_CONFIG_BASE_URL = '/supply-chain-config';
 
 // Supply Chain Config CRUD
 export const getSupplyChainConfigs = async () => {
@@ -25,6 +25,11 @@ export const updateSupplyChainConfig = async (id, configData) => {
 
 export const deleteSupplyChainConfig = async (id) => {
   await api.delete(`${SUPPLY_CHAIN_CONFIG_BASE_URL}/${id}`);
+};
+
+export const trainSupplyChainConfig = async (configId, options = {}) => {
+  const response = await api.post(`${SUPPLY_CHAIN_CONFIG_BASE_URL}/${configId}/train`, options);
+  return response.data;
 };
 
 // Items CRUD


### PR DESCRIPTION
## Summary
- add a lightweight `useFormik` helper to replace the missing third-party form library and keep existing validation behavior
- fix supply chain UI components and services to import the shared axios client correctly and drop redundant `/api/v1` path prefixes
- update admin management screens to call the corrected `/groups`, `/users`, and supply-chain endpoints so config CRUD and training actions succeed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8d0cc1e8c832a8f0e34c366b616db