### PR TITLE
Fix nginx proxy config for GPU compose

### DIFF
--- a/config/dev-proxy/nginx.conf
+++ b/config/dev-proxy/nginx.conf
@@ -14,7 +14,7 @@ http {
 
     # Frontend (served by frontend container's Nginx)
     location / {
-      proxy_pass http://beer-game-frontend:80;
+      proxy_pass http://frontend:80;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -31,7 +31,7 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       # Preserve the /api prefix when forwarding to the backend
-      proxy_pass http://the_beer_game_backend:8000/api/;
+      proxy_pass http://backend:8000/api/;
     }
 
     # WebSockets (backend uses /ws/*)
@@ -40,7 +40,7 @@ http {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
       proxy_set_header Host $host;
-proxy_pass http://the_beer_game_backend:8000;
+      proxy_pass http://backend:8000;
     }
   }
 }


### PR DESCRIPTION
## Summary
- point the development proxy to the docker service names so the GPU stack resolves the backend correctly
- update the frontend upstream entry to use the docker service alias as well

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68c9339d4b84832ab1122e3c77f58c5b