### PR TITLE
Fix proxy health check configuration

### DIFF
--- a/config/dev-proxy/nginx.conf
+++ b/config/dev-proxy/nginx.conf
@@ -42,6 +42,12 @@ http {
       proxy_set_header Host $host;
       proxy_pass http://backend:8000;
     }
+
+    # Container health check endpoint
+    location = /healthz {
+      default_type text/plain;
+      return 200 "ok";
+    }
   }
 }
 

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -14,7 +14,7 @@ services:
         aliases:
           - proxy
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8088"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8088/healthz"]
       interval: 15s
       timeout: 5s
       retries: 4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     networks:
       - beer-game-network
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:80" ]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8088/healthz" ]
       interval: 15s
       timeout: 5s
       retries: 4


### PR DESCRIPTION
## Summary
- add a dedicated /healthz endpoint in the dev proxy nginx config
- update proxy health checks to hit the new endpoint on the correct port in both compose files

## Testing
- not run (docker not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68c935f7a2bc832a98227824665b8297