### PR TITLE
Fix Makefile indentation for seed recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,16 +161,16 @@ proxy-logs:
 	@$(DOCKER_COMPOSE_CMD) -f docker-compose.yml -f docker-compose.proxy.yml logs -f --tail=200 proxy
 
 seed:
-        @echo "\n[+] Seeding default users..."; \
-        $(DOCKER_COMPOSE_CMD) run --rm create-users
+	@echo "\n[+] Seeding default users..."; \
+	$(DOCKER_COMPOSE_CMD) run --rm create-users
 
 seed-default-group:
 	@echo "\n[+] Creating default group, users, and AI-powered game..."; \
 	python backend/scripts/seed_default_group.py
 
 reset-admin:
-        @echo "\n[+] Resetting superadmin password to Daybreak@2025..."; \
-        $(DOCKER_COMPOSE_CMD) exec backend python scripts/reset_admin_password.py
+	@echo "\n[+] Resetting superadmin password to Daybreak@2025..."; \
+	$(DOCKER_COMPOSE_CMD) exec backend python scripts/reset_admin_password.py
 
 setup-default-env:
 	@echo "\n[+] Setting up default environment..."; \


### PR DESCRIPTION
## Summary
- replace space-indented commands in the `seed` and `reset-admin` targets with tab-indented recipes so GNU Make can execute them

## Testing
- make seed-default-group *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c99e7df974832a96f8c85def142a6c