### PR TITLE
Fix SQLite fallback table creation for default group seeding

### DIFF
--- a/backend/scripts/seed_default_group.py
+++ b/backend/scripts/seed_default_group.py
@@ -18,7 +18,8 @@ from sqlalchemy.engine import make_url
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.core.config import settings
-from app.db.base_class import Base, SessionLocal
+from app.db.base_class import SessionLocal
+from app.models import Base as ModelBase
 from app.models import (
     AgentConfig,
     Game,
@@ -63,7 +64,8 @@ def create_sqlite_session_factory() -> Tuple[sessionmaker, Path]:
         fallback_uri,
         connect_args={"check_same_thread": False},
     )
-    Base.metadata.create_all(bind=engine)
+    # Use the SQLAlchemy Base from the models package so all tables are registered
+    ModelBase.metadata.create_all(bind=engine)
     factory = sessionmaker(
         autocommit=False,
         autoflush=False,


### PR DESCRIPTION
## Summary
- ensure the default group seed script uses the models Base metadata when creating the fallback SQLite database
- document why the models Base is required so the fallback creates every table

## Testing
- python scripts/seed_default_group.py *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68ca4158bb50832aa62bb205b8770993