### PR TITLE
Fix SQLite fallback for seeding script

### DIFF
--- a/backend/scripts/seed_default_group.py
+++ b/backend/scripts/seed_default_group.py
@@ -16,6 +16,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
 
 from app.core.config import settings
 from app.db.base_class import SessionLocal
@@ -54,6 +56,13 @@ DEFAULT_AGENT_TYPE = "naive"
 
 FALLBACK_DB_FILENAME = "seed_default_group.sqlite"
 FALLBACK_DB_PATH = BACKEND_ROOT / FALLBACK_DB_FILENAME
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_for_sqlite(type_, compiler, **kw):
+    """Render PostgreSQL JSONB columns as JSON when using SQLite fallback."""
+
+    return "JSON"
 
 
 def create_sqlite_session_factory() -> Tuple[sessionmaker, Path]:


### PR DESCRIPTION
## Summary
- register a SQLite-specific compiler rule so JSONB columns are emitted as JSON during fallback seeding
- add the necessary SQLAlchemy imports to activate the custom compilation

## Testing
- make seed-default-group *(fails: backend/venv is missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca42bd9548832aaca8f631b37071ca