### PR TITLE
Align default seeding with updated user schema

### DIFF
--- a/init_db.sh
+++ b/init_db.sh
@@ -24,18 +24,40 @@ FLUSH PRIVILEGES;
 -- Use the database
 USE \`$DB_NAME\`;
 
--- Create users table if not exists
 CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    username VARCHAR(50) UNIQUE NOT NULL,
-    email VARCHAR(100) UNIQUE NOT NULL,
-    hashed_password VARCHAR(100) NOT NULL,
-    full_name VARCHAR(100),
-    is_active BOOLEAN DEFAULT TRUE,
-    is_superuser BOOLEAN DEFAULT FALSE,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    username VARCHAR(50) NULL,
+    email VARCHAR(100) NOT NULL,
+    hashed_password VARCHAR(255) NOT NULL,
+    full_name VARCHAR(100) NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    is_superuser BOOLEAN NOT NULL DEFAULT FALSE,
+    roles JSON NULL,
+    last_login DATETIME NULL,
+    last_password_change DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    failed_login_attempts INT NOT NULL DEFAULT 0,
+    locked_until DATETIME NULL,
+    mfa_secret VARCHAR(100) NULL,
+    mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_users_username (username),
+    UNIQUE KEY uq_users_email (email)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS groups (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT NULL,
+    logo VARCHAR(255) NULL,
+    admin_id INT NOT NULL,
+    UNIQUE KEY uq_group_admin (admin_id),
+    CONSTRAINT fk_group_admin FOREIGN KEY (admin_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS group_id INT NULL,
+    ADD CONSTRAINT fk_user_group FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE;
 
 -- Insert default users if they don't exist
 INSERT IGNORE INTO users (username, email, hashed_password, full_name, is_superuser, is_active) VALUES

--- a/init_db.sql
+++ b/init_db.sql
@@ -13,15 +13,23 @@ USE beer_game;
 -- Create users table if not exists
 CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    username VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin UNIQUE NOT NULL,
-    email VARCHAR(100) UNIQUE NOT NULL,
-    hashed_password VARCHAR(100) NOT NULL,
-    full_name VARCHAR(100),
-    is_active BOOLEAN DEFAULT TRUE,
-    is_superuser BOOLEAN DEFAULT FALSE,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    INDEX idx_username (username)
+    username VARCHAR(50) NULL,
+    email VARCHAR(100) NOT NULL,
+    hashed_password VARCHAR(255) NOT NULL,
+    full_name VARCHAR(100) NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    is_superuser BOOLEAN NOT NULL DEFAULT FALSE,
+    roles JSON NULL,
+    last_login DATETIME NULL,
+    last_password_change DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    failed_login_attempts INT NOT NULL DEFAULT 0,
+    locked_until DATETIME NULL,
+    mfa_secret VARCHAR(100) NULL,
+    mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_users_username (username),
+    UNIQUE KEY uq_users_email (email)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Create groups table
@@ -35,7 +43,8 @@ CREATE TABLE IF NOT EXISTS groups (
     CONSTRAINT fk_group_admin FOREIGN KEY (admin_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-ALTER TABLE users ADD COLUMN IF NOT EXISTS group_id INT NULL,
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS group_id INT NULL,
     ADD CONSTRAINT fk_user_group FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE;
 
 -- Insert default users if they don't exist


### PR DESCRIPTION
## Summary
- create or update the default administrator before inserting the group so admin_id constraints are satisfied and required roles are present
- update MariaDB bootstrap scripts to provision the full users schema (JSON roles, security metadata, group reference) alongside the groups table
- refresh the legacy security SQL helper to match the ORM column definitions and clean up obsolete columns

## Testing
- python -m compileall backend/scripts/seed_default_group.py

------
https://chatgpt.com/codex/tasks/task_e_68ca4b5beacc832a898f9791375c2954