### PR TITLE
Set seeded games to unsupervised progression

### DIFF
--- a/backend/scripts/ensure_agent_games.py
+++ b/backend/scripts/ensure_agent_games.py
@@ -46,6 +46,7 @@ def ensure_agent_game(session, service: SupplyChainConfigService, group, config,
                 "is_public": True,
             },
         )
+        base_config["progression_mode"] = "unsupervised"
         game = Game(
             name=name,
             description=description,

--- a/backend/scripts/seed_default_group.py
+++ b/backend/scripts/seed_default_group.py
@@ -486,7 +486,7 @@ def ensure_default_game(session: Session, group: Group) -> Game:
                 existing_config = json.loads(existing_config)
             except json.JSONDecodeError:
                 existing_config = {}
-        existing_config.setdefault("progression_mode", "supervised")
+        existing_config["progression_mode"] = "unsupervised"
         game.config = json.loads(json.dumps(existing_config))
         session.add(game)
         return game
@@ -498,7 +498,7 @@ def ensure_default_game(session: Session, group: Group) -> Game:
     game_config = config_service.create_game_from_config(
         sc_config.id, {"name": DEFAULT_GAME_NAME, "max_rounds": 40}
     )
-    game_config["progression_mode"] = "supervised"
+    game_config["progression_mode"] = "unsupervised"
 
     game = Game(
         name=game_config.get("name", DEFAULT_GAME_NAME),
@@ -589,7 +589,7 @@ def configure_human_players_for_game(
     except json.JSONDecodeError:
         config_payload = {}
 
-    config_payload["progression_mode"] = "supervised"
+    config_payload["progression_mode"] = "unsupervised"
     game.config = json.loads(json.dumps(config_payload))
     game.role_assignments = role_assignments
     session.add(game)


### PR DESCRIPTION
## Summary
- default the seeded group game configuration to unsupervised progression
- ensure the showcase Naiive and LLM games are created with unsupervised mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d642fda74c832aafb53cb6bbe9904d