### PR TITLE
Fix supply chain linkage and editable summary in mixed game page

### DIFF
--- a/backend/app/schemas/game.py
+++ b/backend/app/schemas/game.py
@@ -105,6 +105,14 @@ class GameBase(BaseModel):
         default='supervised',
         description="Controls whether the Group Admin advances rounds manually (supervised) or the game auto-progresses once all orders are in (unsupervised)",
     )
+    supply_chain_config_id: Optional[int] = Field(
+        default=None,
+        description="Identifier of the linked supply chain configuration",
+    )
+    supply_chain_name: Optional[str] = Field(
+        default=None,
+        description="Friendly name of the linked supply chain configuration",
+    )
     pricing_config: PricingConfig = Field(
         default_factory=PricingConfig,
         description="Pricing configuration for different roles in the supply chain"
@@ -140,7 +148,9 @@ class GameUpdate(BaseModel):
     max_rounds: Optional[int] = Field(None, ge=1, le=1000)
     description: Optional[str] = Field(None, max_length=500)
     is_public: Optional[bool] = None
-    
+    supply_chain_config_id: Optional[int] = None
+    supply_chain_name: Optional[str] = None
+
     @validator('status')
     def validate_status_transition(cls, v, values, **kwargs):
         # Add any status transition validation here

--- a/frontend/src/pages/CreateMixedGame.js
+++ b/frontend/src/pages/CreateMixedGame.js
@@ -307,9 +307,7 @@ const CreateMixedGame = () => {
 
   const showDaybreakSharingCard = usesDaybreakStrategist || hasDaybreakOverrides;
 
-  const summaryProgressionMode = isEditing && savedSnapshot
-    ? savedSnapshot.progressionMode || 'supervised'
-    : progressionMode;
+  const summaryProgressionMode = progressionMode || 'supervised';
 
   const progressionLabel = useMemo(() => {
     const option = progressionOptions.find((entry) => entry.value === summaryProgressionMode);
@@ -651,7 +649,12 @@ const CreateMixedGame = () => {
         game?.supply_chain_config_id ??
         statePayload?.supply_chain_config_id ??
         null,
-      supplyChainName: config?.name || statePayload?.supply_chain_name || '',
+      supplyChainName:
+        config?.supply_chain_name ??
+        game?.supply_chain_name ??
+        statePayload?.supply_chain_name ??
+        config?.name ??
+        '',
     };
   }, [normalizeLoadedPolicies]);
 
@@ -677,34 +680,18 @@ const CreateMixedGame = () => {
     }
   }, []);
 
-  const summaryGameName = isEditing && savedSnapshot ? savedSnapshot.gameName : gameName;
-  const summaryMaxRounds = isEditing && savedSnapshot ? savedSnapshot.maxRounds : maxRounds;
-  const summaryDemandPattern = isEditing && savedSnapshot ? savedSnapshot.demandPattern : demandPattern;
+  const summaryGameName = gameName;
+  const summaryMaxRounds = maxRounds;
+  const summaryDemandPattern = demandPattern;
 
-  const summaryDemandParams = useMemo(() => {
-    if (isEditing && savedSnapshot) {
-      const params = savedSnapshot.demandParams || {};
-      return {
-        initial_demand: toNumberOr(
-          params.initial_demand ?? params.initialDemand,
-          DEFAULT_CLASSIC_PARAMS.initial_demand
-        ),
-        change_week: toNumberOr(
-          params.change_week ?? params.changeWeek,
-          DEFAULT_CLASSIC_PARAMS.change_week
-        ),
-        final_demand: toNumberOr(
-          params.final_demand ?? params.finalDemand ?? params.new_demand,
-          DEFAULT_CLASSIC_PARAMS.final_demand
-        ),
-      };
-    }
-    return {
-      initial_demand: initialDemand,
-      change_week: demandChangeWeek,
-      final_demand: finalDemand,
-    };
-  }, [isEditing, savedSnapshot, initialDemand, demandChangeWeek, finalDemand]);
+  const summaryDemandParams = useMemo(
+    () => ({
+      initial_demand: toNumberOr(initialDemand, DEFAULT_CLASSIC_PARAMS.initial_demand),
+      change_week: toNumberOr(demandChangeWeek, DEFAULT_CLASSIC_PARAMS.change_week),
+      final_demand: toNumberOr(finalDemand, DEFAULT_CLASSIC_PARAMS.final_demand),
+    }),
+    [initialDemand, demandChangeWeek, finalDemand]
+  );
 
   const demandSummary = useMemo(() => (
     formatDemandPatternSummary(
@@ -1426,6 +1413,7 @@ const CreateMixedGame = () => {
         system_config: systemConfig,
         global_policy: policy,
         supply_chain_config_id: activeSupplyChainConfig?.id || null,
+        supply_chain_name: activeSupplyChainConfig?.name || null,
         pricing_config: {
           retailer: {
             selling_price: parseFloat(pricingConfig.retailer.selling_price),
@@ -1617,7 +1605,7 @@ const CreateMixedGame = () => {
     }
   };
 
-  const summarySupplyChainName = activeSupplyChainConfig?.name || (isEditing && savedSnapshot ? savedSnapshot.supplyChainName : null);
+  const summarySupplyChainName = activeSupplyChainConfig?.name ?? savedSnapshot?.supplyChainName ?? null;
 
   const overviewItems = useMemo(() => [
     { label: 'Game Name', value: summaryGameName || '—' },
@@ -1627,7 +1615,7 @@ const CreateMixedGame = () => {
     { label: 'Linked Supply Chain', value: summarySupplyChainName || '—' },
   ], [summaryGameName, summaryMaxRounds, progressionLabel, demandSummary, summarySupplyChainName, formatNumber]);
 
-  const summaryPolicy = isEditing && savedSnapshot ? savedSnapshot.policy : policy;
+  const summaryPolicy = policy;
 
   const globalPolicyItems = useMemo(() => [
     { label: 'Order Lead Time', value: formatWeeks(summaryPolicy?.info_delay) },
@@ -1639,7 +1627,7 @@ const CreateMixedGame = () => {
     { label: 'Max Inbound / Link', value: formatNumber(summaryPolicy?.max_inbound_per_link) },
   ], [summaryPolicy, formatWeeks, formatNumber, formatCurrency]);
 
-  const summarySystemConfig = isEditing && savedSnapshot ? savedSnapshot.systemConfig : systemConfig;
+  const summarySystemConfig = systemConfig;
 
   const systemConstraintItems = useMemo(() => [
     { label: 'Order Quantity Range', value: formatRangeValue(summarySystemConfig?.min_order_quantity, summarySystemConfig?.max_order_quantity, 'units') },
@@ -1650,7 +1638,7 @@ const CreateMixedGame = () => {
     { label: 'Backlog Cost Range', value: formatCurrencyRange(summarySystemConfig?.min_backlog_cost, summarySystemConfig?.max_backlog_cost) },
   ], [summarySystemConfig, formatRangeValue, formatCurrencyRange]);
 
-  const summaryPlayers = isEditing && savedSnapshot ? savedSnapshot.players : players;
+  const summaryPlayers = players;
 
   const playerSummaryRows = useMemo(() =>
     playerRoles.map(({ value, label }) => {
@@ -1683,8 +1671,8 @@ const CreateMixedGame = () => {
     [summaryPlayers, userLookup]
   );
 
-  const summaryNodePolicies = isEditing && savedSnapshot ? savedSnapshot.nodePolicies : nodePolicies;
-  const summaryPricingConfig = isEditing && savedSnapshot ? savedSnapshot.pricingConfig : pricingConfig;
+  const summaryNodePolicies = nodePolicies;
+  const summaryPricingConfig = pricingConfig;
 
   const roleParameterRows = useMemo(() =>
     playerRoles.map(({ value, label }) => {


### PR DESCRIPTION
## Summary
- persist the selected supply chain configuration on mixed games and expose its metadata in the API
- surface the active supply chain config and editable game settings in the mixed game creator summary card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d642773d48832aa11d096a90145de6