### PR TITLE
Handle invalid Daybreak LLM response fields

### DIFF
--- a/backend/app/services/llm_agent.py
+++ b/backend/app/services/llm_agent.py
@@ -53,9 +53,17 @@ class LLMAgent:
         if payload:
             try:
                 decision = self.session.decide(payload)
-                order_quantity = max(0, int(decision.get("order_upstream", 0)))
-                self._last_ship_plan = max(0, int(decision.get("ship_to_downstream", 0)))
-                rationale = decision.get("rationale", "")
+
+                def _safe_int(value: Any) -> int:
+                    try:
+                        return max(0, int(value))
+                    except (TypeError, ValueError):
+                        return 0
+
+                order_quantity = _safe_int(decision.get("order_upstream", 0))
+                self._last_ship_plan = _safe_int(decision.get("ship_to_downstream", 0))
+                rationale_raw = decision.get("rationale", "")
+                rationale = str(rationale_raw).strip() if rationale_raw is not None else ""
                 ship_fragment = (
                     f" | Proposed ship downstream: {self._last_ship_plan}"
                     if self._last_ship_plan is not None

--- a/backend/app/tests/test_llm_agent_reason.py
+++ b/backend/app/tests/test_llm_agent_reason.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+BACKEND_ROOT = REPO_ROOT / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+def test_llm_agent_records_rationale(monkeypatch):
+    """LLM agent should surface the strategist rationale in its explanation."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=SimpleNamespace))
+
+    from app.services import llm_agent as llm_module
+
+    class DummySession:
+        def __init__(self, model: str):
+            self.model = model
+            self.decide_calls = []
+
+        def decide(self, state):
+            self.decide_calls.append(state)
+            return {
+                "order_upstream": 9,
+                "ship_to_downstream": 4,
+                "rationale": "Maintain a two-week buffer while clearing backlog.",
+            }
+
+        def reset(self):
+            self.decide_calls.clear()
+
+    monkeypatch.setattr(llm_module, "DaybreakStrategistSession", DummySession)
+
+    agent = llm_module.LLMAgent(role="retailer", model="stub-model")
+
+    order = agent.make_decision(
+        current_round=1,
+        current_inventory=10,
+        backorders=2,
+        incoming_shipments=[2, 2],
+        demand_history=[8, 9],
+        order_history=[8, 8],
+        current_demand=8,
+        upstream_data={"llm_payload": {"stub": True}},
+    )
+
+    assert order == 9
+    assert agent.last_explanation is not None
+    assert "Maintain a two-week buffer" in agent.last_explanation


### PR DESCRIPTION
## Summary
- coerce the Daybreak LLM order and shipment values to safe integers so the agent keeps the rationale returned by the strategist
- add a regression test to confirm the LLM agent exposes the strategist rationale in its explanation

## Testing
- pytest backend/app/tests/test_llm_agent_reason.py backend/app/tests/test_daybreak_client.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f3409a74832a81074c912aba23f7