### PR TITLE
Preserve pipeline bookkeeping for zero lead-time orders

### DIFF
--- a/backend/app/services/agent_game_service.py
+++ b/backend/app/services/agent_game_service.py
@@ -342,7 +342,7 @@ class AgentGameService:
         except (TypeError, ValueError):
             ship_val = DEFAULT_SHIPMENT_LEAD_TIME
 
-        return max(1, order_val), max(1, ship_val)
+        return max(0, order_val), max(0, ship_val)
 
     def _get_supply_chain_service(self) -> SupplyChainConfigService | None:
         if self._supply_chain_service is None:

--- a/backend/app/services/engine.py
+++ b/backend/app/services/engine.py
@@ -26,6 +26,7 @@ class Node:
         pipeline_shipments: Iterable[int] | None = None,
         order_pipe: Iterable[int] | None = None,
         last_incoming_order: int = 0,
+        immediate_order_buffer: int = 0,
         cost: float = 0.0,
         shipment_lead_time: int = DEFAULT_SHIPMENT_LEAD_TIME,
         order_lead_time: int = DEFAULT_ORDER_LEAD_TIME,
@@ -36,28 +37,45 @@ class Node:
         self.inventory = int(inventory)
         self.backlog = int(backlog)
 
-        self.shipment_lead_time = max(1, int(shipment_lead_time) if shipment_lead_time is not None else 1)
-        self.order_lead_time = max(1, int(order_lead_time) if order_lead_time is not None else 1)
-
-        self.pipeline_shipments: Deque[int] = deque(
-            list(pipeline_shipments)
-            if pipeline_shipments is not None
-            else [0] * self.shipment_lead_time,
-            maxlen=self.shipment_lead_time,
+        self.shipment_lead_time = max(
+            0, int(shipment_lead_time) if shipment_lead_time is not None else 0
         )
-        while len(self.pipeline_shipments) < self.shipment_lead_time:
-            self.pipeline_shipments.appendleft(0)
-
-        self.order_pipe: Deque[int] = deque(
-            list(order_pipe)
-            if order_pipe is not None
-            else [0] * self.order_lead_time,
-            maxlen=self.order_lead_time,
+        self.order_lead_time = max(
+            0, int(order_lead_time) if order_lead_time is not None else 0
         )
-        while len(self.order_pipe) < self.order_lead_time:
-            self.order_pipe.appendleft(0)
+
+        if self.shipment_lead_time > 0:
+            self.pipeline_shipments: Deque[int] = deque(
+                list(pipeline_shipments)
+                if pipeline_shipments is not None
+                else [0] * self.shipment_lead_time,
+                maxlen=self.shipment_lead_time,
+            )
+            while len(self.pipeline_shipments) < self.shipment_lead_time:
+                self.pipeline_shipments.appendleft(0)
+        else:
+            self.pipeline_shipments = deque()
+
+        if self.order_lead_time > 0:
+            self.order_pipe: Deque[int] = deque(
+                list(order_pipe)
+                if order_pipe is not None
+                else [0] * self.order_lead_time,
+                maxlen=self.order_lead_time,
+            )
+            while len(self.order_pipe) < self.order_lead_time:
+                self.order_pipe.appendleft(0)
+        else:
+            initial = 0
+            if order_pipe:
+                try:
+                    initial = int(next(iter(order_pipe)))
+                except StopIteration:
+                    initial = 0
+            self.order_pipe = deque([initial], maxlen=1)
 
         self.last_incoming_order = int(last_incoming_order)
+        self._immediate_order_buffer = max(0, int(immediate_order_buffer))
         self.cost = float(cost)
 
     # ------------------------------------------------------------------
@@ -81,6 +99,9 @@ class Node:
     def receive_shipment(self) -> int:
         """Advance the shipment pipeline and add arrivals to on-hand inventory."""
 
+        if self.shipment_lead_time <= 0:
+            return 0
+
         arrived = self.pipeline_shipments.popleft()
         self.pipeline_shipments.append(0)
         self.inventory += arrived
@@ -88,6 +109,13 @@ class Node:
 
     def shift_order_pipe(self) -> int:
         """Advance the outbound order pipeline (orders travelling upstream)."""
+
+        if self.order_lead_time <= 0:
+            due_upstream = self._immediate_order_buffer
+            self._immediate_order_buffer = 0
+            if self.order_pipe:
+                self.order_pipe[0] = 0
+            return due_upstream
 
         due_upstream = self.order_pipe.popleft()
         self.order_pipe.append(0)
@@ -97,15 +125,29 @@ class Node:
         """Queue a shipment that will arrive after the shipment lead time."""
 
         qty = int(quantity)
-        if qty > 0:
-            self.pipeline_shipments[-1] += qty
+        if qty <= 0:
+            return
+
+        if self.shipment_lead_time <= 0:
+            self.inventory += qty
+            return
+
+        self.pipeline_shipments[-1] += qty
 
     def schedule_order(self, quantity: int) -> None:
         """Queue an order that will reach the upstream partner after the delay."""
 
         qty = int(quantity)
-        if qty > 0:
-            self.order_pipe[-1] += qty
+        if qty <= 0:
+            return
+
+        if self.order_lead_time <= 0:
+            self._immediate_order_buffer += qty
+            if self.order_pipe:
+                self.order_pipe[0] = self._immediate_order_buffer
+            return
+
+        self.order_pipe[-1] += qty
 
     def decide_order(self) -> int:
         """Call the node's policy to determine the order for this week."""
@@ -142,6 +184,7 @@ class Node:
             "backlog": self.backlog,
             "pipeline_shipments": list(self.pipeline_shipments),
             "order_pipe": list(self.order_pipe),
+            "immediate_order_buffer": self._immediate_order_buffer,
             "last_incoming_order": self.last_incoming_order,
             "cost": self.cost,
             "base_stock": self.base_stock,
@@ -170,6 +213,7 @@ class Node:
             backlog=int(state.get("backlog", 0)),
             pipeline_shipments=state.get("pipeline_shipments"),
             order_pipe=state.get("order_pipe"),
+            immediate_order_buffer=int(state.get("immediate_order_buffer", 0)),
             last_incoming_order=int(state.get("last_incoming_order", 0)),
             cost=float(state.get("cost", 0.0)),
             shipment_lead_time=int(state_shipment_lead),
@@ -206,8 +250,12 @@ class BeerLine:
         base_stocks = base_stocks or {}
 
         self.role_names = self.role_sequence_names()
-        self.shipment_lead_time = max(1, int(shipment_lead_time) if shipment_lead_time is not None else 1)
-        self.order_lead_time = max(1, int(order_lead_time) if order_lead_time is not None else 1)
+        self.shipment_lead_time = max(
+            0, int(shipment_lead_time) if shipment_lead_time is not None else 0
+        )
+        self.order_lead_time = max(
+            0, int(order_lead_time) if order_lead_time is not None else 0
+        )
 
         self.nodes: List[Node] = []
         for role in self.role_names:
@@ -297,31 +345,30 @@ class BeerLine:
                 "backlog_before": node.backlog,
             }
 
-        # Step 2 – Observe inbound orders and advance outbound order pipelines
+        # Step 2/3/4/5 – Traverse nodes downstream → upstream within the same tick
         incoming_orders: List[int] = [0] * len(self.nodes)
-        incoming_orders[0] = demand
-        self.nodes[0].last_incoming_order = demand
-        stats[self.nodes[0].name]["incoming_order"] = demand
-        stats[self.nodes[0].name]["order_due"] = demand
-        stats[self.nodes[0].name]["last_incoming_order"] = demand
+        if self.nodes:
+            incoming_orders[0] = demand
+            stats[self.nodes[0].name]["order_due"] = demand
 
-        for idx in range(len(self.nodes) - 1):
-            downstream = self.nodes[idx]
-            upstream = self.nodes[idx + 1]
-            due_upstream = downstream.shift_order_pipe()
-            incoming_orders[idx + 1] = due_upstream
-            upstream.last_incoming_order = due_upstream
-            stats[upstream.name]["incoming_order"] = due_upstream
-            stats[upstream.name]["order_due"] = due_upstream
-            stats[upstream.name]["last_incoming_order"] = due_upstream
-            stats[downstream.name]["order_pipe"] = list(downstream.order_pipe)
-
-        # Ensure the manufacturer has order_pipe stats even though it has no upstream
-        stats[self.nodes[-1].name]["order_pipe"] = list(self.nodes[-1].order_pipe)
-
-        # Step 3 – Ship to downstream partner, prioritising backlog first
         for idx, node in enumerate(self.nodes):
-            need = node.backlog + incoming_orders[idx]
+            # Advance any outstanding orders travelling upstream from this node.
+            if idx < len(self.nodes) - 1:
+                due_upstream = node.shift_order_pipe()
+                if due_upstream:
+                    incoming_orders[idx + 1] += due_upstream
+                upstream_stats = stats[self.nodes[idx + 1].name]
+                upstream_stats["order_due"] = incoming_orders[idx + 1]
+                upstream_stats["incoming_order"] = incoming_orders[idx + 1]
+                upstream_stats["last_incoming_order"] = incoming_orders[idx + 1]
+
+            incoming = incoming_orders[idx]
+            node.last_incoming_order = incoming
+            stats[node.name]["incoming_order"] = incoming
+            stats[node.name]["last_incoming_order"] = incoming
+            stats[node.name]["order_due"] = incoming
+
+            need = node.backlog + incoming
             shipped = min(node.inventory, need)
             node.inventory -= shipped
             node.backlog = max(need - shipped, 0)
@@ -340,19 +387,31 @@ class BeerLine:
             if idx > 0:
                 downstream = self.nodes[idx - 1]
                 downstream.schedule_inbound_shipment(shipped)
+                downstream_stats = stats[downstream.name]
+                downstream_stats["inventory_after"] = downstream.inventory
+                downstream_stats["inventory_position"] = downstream.inventory - downstream.backlog
 
-        # Step 4/5 – Decide new orders and queue them in the outbound pipelines
-        for idx, node in enumerate(self.nodes):
             order_qty = node.decide_order()
             stats[node.name]["order_placed"] = order_qty
 
             if idx < len(self.nodes) - 1:
                 node.schedule_order(order_qty)
                 stats[node.name]["order_pipe"] = list(node.order_pipe)
+
+                if node.order_lead_time == 0:
+                    due_now = node.shift_order_pipe()
+                    if due_now:
+                        incoming_orders[idx + 1] += due_now
+                upstream_stats = stats[self.nodes[idx + 1].name]
+                upstream_stats["order_due"] = incoming_orders[idx + 1]
+                upstream_stats["incoming_order"] = incoming_orders[idx + 1]
+                upstream_stats["last_incoming_order"] = incoming_orders[idx + 1]
             else:
                 # Manufacturer starts production that feeds its own shipment pipeline
                 node.schedule_inbound_shipment(order_qty)
+                stats[node.name]["order_pipe"] = list(node.order_pipe)
 
+        for node in self.nodes:
             stats[node.name]["pipeline_on_order"] = node.pipeline_on_order
             stats[node.name]["inventory_position_with_pipeline"] = node.inventory_position
             stats[node.name]["inventory_position"] = node.inventory - node.backlog

--- a/backend/app/tests/test_engine.py
+++ b/backend/app/tests/test_engine.py
@@ -20,3 +20,30 @@ def test_inventory_position_matches_onhand_minus_backlog():
         assert role_stats["inventory_position"] == role_stats["inventory_after"] - role_stats["backlog_after"]
         assert role_stats["inventory_position"] == node.inventory - node.backlog
         assert role_stats["inventory_position_with_pipeline"] == node.inventory_position
+
+
+def test_zero_order_lead_propagates_orders_immediately():
+    line = BeerLine(order_lead_time=0)
+
+    for node in line.nodes:
+        node.inventory = 20
+        node.backlog = 0
+
+    stats = line.tick(customer_demand=4)
+
+    # All upstream partners should see the retailer's order in the same tick.
+    assert stats["Retailer"]["incoming_order"] == 4
+    assert stats["Wholesaler"]["incoming_order"] == 4
+    assert stats["Distributor"]["incoming_order"] == 4
+    assert stats["Manufacturer"]["incoming_order"] == 4
+
+    # Orders are still queued through the pipeline bookkeeping, even with zero delay.
+    assert stats["Retailer"]["order_pipe"] == [4]
+    assert stats["Wholesaler"]["order_pipe"] == [4]
+    assert stats["Distributor"]["order_pipe"] == [4]
+    assert stats["Manufacturer"]["order_pipe"] == [0]
+
+    # Shipments respond immediately to the observed demand, preventing upstream starvation.
+    assert stats["Wholesaler"]["demand"] == 4
+    assert stats["Distributor"]["demand"] == 4
+    assert stats["Manufacturer"]["demand"] == 4

--- a/backend/gpt_app.py
+++ b/backend/gpt_app.py
@@ -21,8 +21,17 @@ def get_order():
     else:
         pipeline_shipments = [int(expected_deliveries or 0)]
 
-    order_lead = int(data.get("order_lead_time", 2))
-    ship_lead = int(data.get("shipping_lead_time", 2))
+    try:
+        order_lead = int(data.get("order_lead_time", 2))
+    except (TypeError, ValueError):
+        order_lead = 2
+    try:
+        ship_lead = int(data.get("shipping_lead_time", 2))
+    except (TypeError, ValueError):
+        ship_lead = 2
+
+    order_lead = max(order_lead, 0)
+    ship_lead = max(ship_lead, 0)
 
     while len(pipeline_shipments) < max(ship_lead, 0):
         pipeline_shipments.append(0)


### PR DESCRIPTION
## Summary
- keep zero lead-time orders in each node's pipeline bookkeeping via an immediate-order buffer
- let the traversal release queued zero-delay orders in the same round while retaining pipeline snapshots
- update the regression to assert the pipeline contents for the zero lead-time scenario

## Testing
- PYTHONPATH=. pytest backend/app/tests/test_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d7765325ac832aaea626eaa867524b