### PR TITLE
Attach resource files when creating strategist session

### DIFF
--- a/backend/llm_agent/resources/__init__.py
+++ b/backend/llm_agent/resources/__init__.py
@@ -1,0 +1,18 @@
+"""Resource package for Daybreak Beer Game Strategist assets."""
+
+from importlib import resources as _resources
+from pathlib import Path as _Path
+from typing import Iterator as _Iterator
+
+__all__ = ["iter_files"]
+
+
+def iter_files() -> _Iterator[_Path]:
+    """Yield filesystem paths to packaged asset files."""
+
+    package_root = _resources.files(__name__)
+    with _resources.as_file(package_root) as resolved_root:
+        root_path = _Path(resolved_root)
+        for file_path in root_path.rglob("*"):
+            if file_path.is_file() and file_path.name != "__init__.py":
+                yield file_path


### PR DESCRIPTION
## Summary
- load Beer Game resource files from the `backend.llm_agent.resources` package and upload them to OpenAI file storage
- cache uploaded file IDs and attach them when creating the Daybreak strategist Responses session so the custom GPT has access to bundled assets
- add a resources package scaffold to support packaging the shared assets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7cbddd58c832a9570802a97d36805