### PR TITLE
Ensure Daybreak LLM rationale is captured

### DIFF
--- a/backend/app/tests/test_llm_agent_reason.py
+++ b/backend/app/tests/test_llm_agent_reason.py
@@ -54,3 +54,87 @@ def test_llm_agent_records_rationale(monkeypatch):
     assert order == 9
     assert agent.last_explanation is not None
     assert "Maintain a two-week buffer" in agent.last_explanation
+    assert agent.last_decision == {
+        "order_upstream": 9,
+        "ship_to_downstream": 4,
+        "rationale": "Maintain a two-week buffer while clearing backlog.",
+    }
+
+
+def test_llm_agent_records_fallback_reason(monkeypatch):
+    """If the payload is missing the agent should document its fallback."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=SimpleNamespace))
+
+    from app.services import llm_agent as llm_module
+
+    class DummySession:
+        def __init__(self, model: str):
+            self.model = model
+
+        def decide(self, state):  # pragma: no cover - shouldn't be hit
+            raise AssertionError("Decide should not be called without payload")
+
+        def reset(self):
+            pass
+
+    monkeypatch.setattr(llm_module, "DaybreakStrategistSession", DummySession)
+
+    agent = llm_module.LLMAgent(role="retailer", model="stub-model")
+
+    order = agent.make_decision(
+        current_round=1,
+        current_inventory=10,
+        backorders=2,
+        incoming_shipments=[2, 2],
+        demand_history=[8, 9],
+        order_history=[8, 8],
+        current_demand=8,
+        upstream_data={"other": "context"},
+    )
+
+    assert order >= 0
+    assert agent.last_decision is None
+    assert agent.last_explanation is not None
+    assert "fallback" in agent.last_explanation.lower()
+
+
+def test_llm_agent_records_error_reason(monkeypatch):
+    """Errors surfaced by the strategist should translate to fallback notes."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=SimpleNamespace))
+
+    from app.services import llm_agent as llm_module
+
+    class FailingSession:
+        def __init__(self, model: str):
+            self.model = model
+
+        def decide(self, state):
+            raise RuntimeError("boom")
+
+        def reset(self):
+            pass
+
+    monkeypatch.setattr(llm_module, "DaybreakStrategistSession", FailingSession)
+
+    agent = llm_module.LLMAgent(role="retailer", model="stub-model")
+
+    order = agent.make_decision(
+        current_round=1,
+        current_inventory=10,
+        backorders=2,
+        incoming_shipments=[2, 2],
+        demand_history=[8, 9],
+        order_history=[8, 8],
+        current_demand=8,
+        upstream_data={"llm_payload": {"stub": True}},
+    )
+
+    assert order >= 0
+    assert agent.last_decision is None
+    assert agent.last_explanation is not None
+    assert "fallback" in agent.last_explanation.lower()
+    assert "boom" in agent.last_explanation


### PR DESCRIPTION
## Summary
- track the most recent Daybreak strategist decision so the raw rationale can be reused
- surface informative fallback messages when no payload is available or the strategist fails
- extend LLMAgent tests to cover rationale persistence and fallback messaging

## Testing
- pytest backend/app/tests/test_llm_agent_reason.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e7931b8c832aa6c6257f41574a75